### PR TITLE
Confirmation dialogs for deleting conversations

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
@@ -19,7 +19,7 @@ public class ClearAllConversationsAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
-    int answer = Messages.showYesNoDialog("Are you sure you want to delete all conversations?","Clear History", DefaultImageIcon);
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete all conversations?", "Clear History", DefaultImageIcon);
     if (answer == Messages.YES) {
       ConversationsState.getInstance().clearAll();
       this.onRefresh.run();

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
@@ -19,7 +19,7 @@ public class ClearAllConversationsAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
-    int answer = Messages.showYesNoDialog("Are you sure you want to delete all convesation?","Clear History", DefaultImageIcon);
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete all conversations?","Clear History", DefaultImageIcon);
     if (answer == Messages.YES) {
       ConversationsState.getInstance().clearAll();
       this.onRefresh.run();

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
@@ -3,6 +3,7 @@ package ee.carlrobert.codegpt.toolwindow.conversations.actions;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ui.Messages;
 import ee.carlrobert.codegpt.conversations.ConversationsState;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,10 @@ public class ClearAllConversationsAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
-    ConversationsState.getInstance().clearAll();
-    this.onRefresh.run();
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete all convesation?", "Clear History", null);
+    if (answer == Messages.YES) {
+      ConversationsState.getInstance().clearAll();
+      this.onRefresh.run();
+    }
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/ClearAllConversationsAction.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ui.Messages;
 import ee.carlrobert.codegpt.conversations.ConversationsState;
 import org.jetbrains.annotations.NotNull;
+import static icons.Icons.DefaultImageIcon;
 
 public class ClearAllConversationsAction extends AnAction {
 
@@ -18,7 +19,7 @@ public class ClearAllConversationsAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
-    int answer = Messages.showYesNoDialog("Are you sure you want to delete all convesation?", "Clear History", null);
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete all convesation?","Clear History", DefaultImageIcon);
     if (answer == Messages.YES) {
       ConversationsState.getInstance().clearAll();
       this.onRefresh.run();

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
@@ -19,7 +19,7 @@ public class DeleteConversationAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
-    int answer = Messages.showYesNoDialog("Are you sure you want to delete this conversation?","Delete Converation", DefaultImageIcon);
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete this conversation?", "Delete Converation", DefaultImageIcon);
     if (answer == Messages.YES) {
       ConversationsState.getInstance().deleteSelectedConversation();
       onRefresh.run();

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
@@ -19,7 +19,7 @@ public class DeleteConversationAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
-    int answer = Messages.showYesNoDialog("Are you sure you want to delete this convesation?","Delete Converation", DefaultImageIcon);
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete this conversation?","Delete Converation", DefaultImageIcon);
     if (answer == Messages.YES) {
       ConversationsState.getInstance().deleteSelectedConversation();
       onRefresh.run();

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ui.Messages;
 import ee.carlrobert.codegpt.conversations.ConversationsState;
 import org.jetbrains.annotations.NotNull;
+import static icons.Icons.DefaultImageIcon;
 
 public class DeleteConversationAction extends AnAction {
 
@@ -18,7 +19,7 @@ public class DeleteConversationAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
-    int answer = Messages.showYesNoDialog("Are you sure you want to delete this convesation?", "Delete Converation", null);
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete this convesation?","Delete Converation", DefaultImageIcon);
     if (answer == Messages.YES) {
       ConversationsState.getInstance().deleteSelectedConversation();
       onRefresh.run();

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/actions/DeleteConversationAction.java
@@ -3,6 +3,7 @@ package ee.carlrobert.codegpt.toolwindow.conversations.actions;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ui.Messages;
 import ee.carlrobert.codegpt.conversations.ConversationsState;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,10 @@ public class DeleteConversationAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
-    ConversationsState.getInstance().deleteSelectedConversation();
-    onRefresh.run();
+    int answer = Messages.showYesNoDialog("Are you sure you want to delete this convesation?", "Delete Converation", null);
+    if (answer == Messages.YES) {
+      ConversationsState.getInstance().deleteSelectedConversation();
+      onRefresh.run();
+    }
   }
 }


### PR DESCRIPTION
A fix for this issue: https://github.com/carlrobertoh/CodeGPT/issues/57

Show a confirmation dialog when clicking the "Delete Conversation" and "Delete All" buttons in the "Conversation History" tab. This will prevent the accidental removal of conversations that may be important for a user.