### PR TITLE
Change how placeholder text is displayed and hidden

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/components/TextArea.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/components/TextArea.java
@@ -8,18 +8,16 @@ import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.JBUI;
 import icons.Icons;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import javax.swing.JButton;
 import javax.swing.JScrollPane;
 
 public class TextArea extends JBTextArea {
 
   public TextArea(Runnable onSubmit, JScrollPane textAreaScrollPane) {
-    super("Ask me anything...");
+    super();
+    getEmptyText().setText("Ask me anything...");
     setForeground(JBColor.GRAY);
     setMargin(JBUI.insets(5));
-    addFocusListener(getFocusListener());
     addSubmitButton(onSubmit, textAreaScrollPane);
     addShiftEnterInputMap(this, onSubmit);
   }
@@ -35,23 +33,5 @@ public class TextArea extends JBTextArea {
     var button = createIconButton(Icons.SendImageIcon);
     button.addActionListener(submitButtonListener);
     return button;
-  }
-
-  private FocusListener getFocusListener() {
-    return new FocusListener() {
-      public void focusGained(FocusEvent e) {
-        if (getText().equals("Ask me anything...")) {
-          setText("");
-          setForeground(JBColor.BLACK);
-        }
-      }
-
-      public void focusLost(FocusEvent e) {
-        if (getText().isEmpty()) {
-          setForeground(JBColor.GRAY);
-          setText("Ask me anything...");
-        }
-      }
-    };
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/components/TextArea.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/components/TextArea.java
@@ -3,7 +3,6 @@ package ee.carlrobert.codegpt.toolwindow.components;
 import static ee.carlrobert.codegpt.util.SwingUtils.addShiftEnterInputMap;
 import static ee.carlrobert.codegpt.util.SwingUtils.createIconButton;
 
-import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.JBUI;
 import icons.Icons;
@@ -16,7 +15,6 @@ public class TextArea extends JBTextArea {
   public TextArea(Runnable onSubmit, JScrollPane textAreaScrollPane) {
     super();
     getEmptyText().setText("Ask me anything...");
-    setForeground(JBColor.GRAY);
     setMargin(JBUI.insets(5));
     addSubmitButton(onSubmit, textAreaScrollPane);
     addShiftEnterInputMap(this, onSubmit);


### PR DESCRIPTION
- based on the IntelliJ Platform UI Guidelines https://jetbrains.design/intellij/controls/input_field/#placeholder "Hide the placeholder when the user starts typing, not when the input field gets the focus."
- remove focus event and listener

I was running into an issue where if you paste by using middle click in Linux, the placeholder text would not be erased first, and the pasted text and the placeholder end up being combined.