### PR TITLE
Add custom API host to allow users to set up reverse proxy for OpenAI…

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/client/ClientProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/client/ClientProvider.java
@@ -35,6 +35,10 @@ public class ClientProvider {
     var settings = SettingsState.getInstance();
     var builder = new OpenAIClient.Builder(settings.apiKey);
 
+    if (!settings.apiHost.isEmpty()){
+      builder.setHost(settings.apiHost);
+    }
+
     if (settings.useOpenAIService) {
       builder.setOrganization(settings.organization);
     }

--- a/src/main/java/ee/carlrobert/codegpt/state/settings/SettingsComponent.java
+++ b/src/main/java/ee/carlrobert/codegpt/state/settings/SettingsComponent.java
@@ -15,16 +15,14 @@ import ee.carlrobert.openai.client.completion.text.TextCompletionModel;
 import java.awt.Desktop;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.JComponent;
-import javax.swing.JPanel;
+import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
 
 public class SettingsComponent {
 
   private final JPanel mainPanel;
   private final JBTextField apiKeyField;
+  private final JBTextField apiHostField;
   private final JBTextField organizationField;
   private final JBTextField resourceNameField;
   private final JBTextField deploymentIdField;
@@ -41,6 +39,8 @@ public class SettingsComponent {
 
   public SettingsComponent(SettingsState settings) {
     apiKeyField = new JBTextField(settings.apiKey, 40);
+    apiHostField = new JBTextField(settings.apiHost,40);
+    apiHostField.setInputVerifier(HostInputVerifier());
     useOpenAIServiceRadioButton = new JBRadioButton("Use OpenAI service API",
         settings.useOpenAIService);
     useAzureServiceRadioButton = new JBRadioButton("Use Azure OpenAI service API",
@@ -107,6 +107,14 @@ public class SettingsComponent {
 
   public void setApiKey(String apiKey) {
     apiKeyField.setText(apiKey);
+  }
+
+  public String getApiHost() {
+    return apiHostField.getText();
+  }
+
+  public void setApiHost(String apiHost) {
+    apiHostField.setText(apiHost);
   }
 
   public void setUseOpenAIServiceSelected(boolean selected) {
@@ -221,13 +229,22 @@ public class SettingsComponent {
             "You can find your Secret API key in your <a href=\"https://platform.openai.com/account/api-keys\">User settings</a>.")
         .withCommentHyperlinkListener(this::handleHyperlinkClicked)
         .createPanel();
+    var apiHostFieldPanel = UI.PanelFactory.panel(apiHostField)
+            .withLabel("API Host:")
+            .resizeX(false)
+            .withComment(
+                    "You can input your api host. default: https://api.openai.com")
+            .withCommentHyperlinkListener(this::handleHyperlinkClicked)
+            .createPanel();
     var displayNameFieldPanel = SwingUtils.createPanel(displayNameField, "Display name:", false);
 
     SwingUtils.setEqualLabelWidths(apiKeyFieldPanel, displayNameFieldPanel);
+    SwingUtils.setEqualLabelWidths(apiHostFieldPanel, displayNameFieldPanel);
 
     var panel = FormBuilder.createFormBuilder()
         .addComponent(FormBuilder.createFormBuilder()
             .addComponent(apiKeyFieldPanel)
+            .addComponent(apiHostFieldPanel)
             .addComponent(displayNameFieldPanel)
             .addComponent(useOpenAIAccountNameCheckBox)
             .getPanel())
@@ -369,5 +386,19 @@ public class SettingsComponent {
         }
       }
     }
+  }
+
+  private InputVerifier HostInputVerifier(){
+    return new InputVerifier() {
+      @Override
+      public boolean verify(JComponent input) {
+        String text = ((JTextField) input).getText();
+        boolean valid = text.matches("^(http|https)://([\\w-]+\\.)+[\\w-]+(/[\\w- ./?%&=]*)?$");
+        if (!valid) {
+          JOptionPane.showMessageDialog(input, "Please input right Host！like: https://api.openai.com");
+        }
+        return valid;
+      }
+    };
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/state/settings/SettingsConfigurable.java
+++ b/src/main/java/ee/carlrobert/codegpt/state/settings/SettingsConfigurable.java
@@ -37,6 +37,7 @@ public class SettingsConfigurable implements Configurable {
   public boolean isModified() {
     var settings = SettingsState.getInstance();
     return !settingsComponent.getApiKey().equals(settings.apiKey) ||
+            !settingsComponent.getApiHost().equals(settings.apiHost) ||
         settingsComponent.isUseOpenAIService() != settings.useOpenAIService ||
         settingsComponent.isUseAzureService() != settings.useAzureService ||
         settingsComponent.isUseActiveDirectoryAuthentication() !=
@@ -77,6 +78,7 @@ public class SettingsConfigurable implements Configurable {
     }
 
     settings.apiKey = settingsComponent.getApiKey();
+    settings.apiHost = settingsComponent.getApiHost();
     settings.useOpenAIService = settingsComponent.isUseOpenAIService();
     settings.useAzureService = settingsComponent.isUseAzureService();
     settings.useActiveDirectoryAuthentication = settingsComponent.isUseActiveDirectoryAuthentication();
@@ -98,6 +100,7 @@ public class SettingsConfigurable implements Configurable {
     settingsComponent.setUseChatCompletionSelected(settings.isChatCompletionOptionSelected);
     settingsComponent.setUseTextCompletionSelected(settings.isTextCompletionOptionSelected);
     settingsComponent.setApiKey(settings.apiKey);
+    settingsComponent.setApiHost(settings.apiHost);
     settingsComponent.setUseOpenAIServiceSelected(settings.useAzureService);
     settingsComponent.setUseAzureServiceSelected(settings.useAzureService);
     settingsComponent.setUseActiveDirectoryAuthenticationSelected(

--- a/src/main/java/ee/carlrobert/codegpt/state/settings/SettingsState.java
+++ b/src/main/java/ee/carlrobert/codegpt/state/settings/SettingsState.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 public class SettingsState implements PersistentStateComponent<SettingsState> {
 
   public String apiKey = "";
+  public String apiHost = "";
   public boolean useOpenAIService = true;
   public boolean useAzureService;
   public String resourceName = "";


### PR DESCRIPTION
To make it easier for users to set up reverse proxy for OpenAI's custom domain API host, we can add a custom API host text box on the settings page, allowing users to enter the API host they want to use.