### PR TITLE
Move the CodeGPT Telemetry settings screen.

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,10 +13,10 @@
         <applicationConfigurable id="settings.codegpt.advanced" parentId="settings.codegpt" displayName="Advanced Settings"
             instance="ee.carlrobert.codegpt.settings.advanced.AdvancedSettingsConfigurable"/>
         <applicationConfigurable
-          parentId="tools"
+          parentId="settings.codegpt"
           instance="ee.carlrobert.codegpt.telemetry.ui.preferences.TelemetryConfigurable"
           id="tools.preferences.codegpt.telemetry"
-          displayName="CodeGPT Telemetry"/>
+          displayName="Telemetry"/>
         <applicationService
           serviceImplementation="ee.carlrobert.codegpt.telemetry.core.service.TelemetryServiceFactory"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.state.SettingsState"/>


### PR DESCRIPTION
The CodeGPT Telemetry settings screen was previously a 'stand-alone' configuration window under the 'Tools' section of the IDEA settings. Moving it under the parent plugin makes it more apparent and keeps it better organized.