### PR TITLE
Renamed `id` property on `Conversation` to `localId`

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestHandler.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestHandler.java
@@ -223,7 +223,7 @@ public class CompletionRequestHandler {
         service = "you";
       }
       TelemetryAction.COMPLETION.createActionMessage()
-          .property("conversationId", conversation.getId().toString())
+          .property("conversationId", conversation.getLocalId().toString())
           .property("model", conversation.getModel())
           .property("service", service)
           .send();
@@ -231,7 +231,7 @@ public class CompletionRequestHandler {
 
     private void sendError(ErrorDetails error, Throwable ex) {
       TelemetryAction.COMPLETION_ERROR.createActionMessage()
-          .property("conversationId", conversation.getId().toString())
+          .property("conversationId", conversation.getLocalId().toString())
           .property("model", conversation.getModel())
           .error(new RuntimeException(error.toString(), ex))
           .send();

--- a/src/main/java/ee/carlrobert/codegpt/conversations/Conversation.java
+++ b/src/main/java/ee/carlrobert/codegpt/conversations/Conversation.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public class Conversation {
 
-  private UUID id;
+  private UUID localId;
   private List<Message> messages = new ArrayList<>();
   private String clientCode;
   private String model;
@@ -18,12 +18,12 @@ public class Conversation {
   private LocalDateTime updatedOn;
   private boolean discardTokenLimit;
 
-  public UUID getId() {
-    return id;
+  public UUID getLocalId() {
+    return localId;
   }
 
-  public void setId(UUID id) {
-    this.id = id;
+  public void setLocalId(UUID localId) {
+    this.localId = localId;
   }
 
   public List<Message> getMessages() {

--- a/src/main/java/ee/carlrobert/codegpt/conversations/ConversationService.java
+++ b/src/main/java/ee/carlrobert/codegpt/conversations/ConversationService.java
@@ -40,7 +40,7 @@ public final class ConversationService {
   public Conversation createConversation(String clientCode) {
     var settings = SettingsState.getInstance();
     var conversation = new Conversation();
-    conversation.setId(UUID.randomUUID());
+    conversation.setLocalId(UUID.randomUUID());
     conversation.setClientCode(clientCode);
     if (settings.isUseYouService()) {
       conversation.setModel("YouCode");
@@ -94,7 +94,7 @@ public final class ConversationService {
             }
             return item;
           }).collect(toList()));
-      if (next.getId().equals(conversation.getId())) {
+      if (next.getLocalId().equals(conversation.getLocalId())) {
         iterator.set(conversation);
       }
     }
@@ -107,7 +107,7 @@ public final class ConversationService {
         .listIterator();
     while (iterator.hasNext()) {
       var next = iterator.next();
-      if (next.getId().equals(conversation.getId())) {
+      if (next.getLocalId().equals(conversation.getLocalId())) {
         iterator.set(conversation);
       }
     }
@@ -151,7 +151,7 @@ public final class ConversationService {
       var sortedConversations = getSortedConversations();
       for (int i = 0; i < sortedConversations.size(); i++) {
         var conversation = sortedConversations.get(i);
-        if (conversation != null && conversation.getId().equals(currentConversation.getId())) {
+        if (conversation != null && conversation.getLocalId().equals(currentConversation.getLocalId())) {
           // higher index indicates older conversation
           var previousIndex = isPrevious ? i + 1 : i - 1;
           if (isPrevious ? previousIndex < sortedConversations.size() : previousIndex != -1) {
@@ -169,7 +169,7 @@ public final class ConversationService {
         .listIterator();
     while (iterator.hasNext()) {
       var next = iterator.next();
-      if (next.getId().equals(conversation.getId())) {
+      if (next.getLocalId().equals(conversation.getLocalId())) {
         iterator.remove();
         break;
       }

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/standard/StandardChatToolWindowContentManager.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/standard/StandardChatToolWindowContentManager.java
@@ -52,7 +52,7 @@ public final class StandardChatToolWindowContentManager {
   public void displayConversation(Conversation conversation) {
     displayChatTab();
     tryFindChatTabbedPane()
-        .ifPresent(tabbedPane -> tabbedPane.tryFindActiveConversationTitle(conversation.getId())
+        .ifPresent(tabbedPane -> tabbedPane.tryFindActiveConversationTitle(conversation.getLocalId())
             .ifPresentOrElse(
                 title -> tabbedPane.setSelectedIndex(tabbedPane.indexOfTab(title)),
                 () -> tabbedPane.addNewTab(new StandardChatToolWindowTabPanel(project, conversation))));

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/standard/StandardChatToolWindowTabbedPane.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/standard/StandardChatToolWindowTabbedPane.java
@@ -72,7 +72,7 @@ public class StandardChatToolWindowTabbedPane extends JBTabbedPane {
     return activeTabMapping.entrySet().stream()
         .filter(entry -> {
           var panelConversation = entry.getValue().getConversation();
-          return panelConversation != null && conversationId.equals(panelConversation.getId());
+          return panelConversation != null && conversationId.equals(panelConversation.getLocalId());
         })
         .findFirst()
         .map(Map.Entry::getKey);

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/ConversationPanel.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/conversations/ConversationPanel.java
@@ -48,7 +48,7 @@ class ConversationPanel extends JPanel {
 
   private boolean isSelected(Conversation conversation) {
     var currentConversation = ConversationsState.getCurrentConversation();
-    return currentConversation != null && currentConversation.getId().equals(conversation.getId());
+    return currentConversation != null && currentConversation.getLocalId().equals(conversation.getLocalId());
   }
 
   private void addStyles(boolean isSelected) {

--- a/src/test/java/ee/carlrobert/codegpt/conversations/ConversationsStateTest.java
+++ b/src/test/java/ee/carlrobert/codegpt/conversations/ConversationsStateTest.java
@@ -75,8 +75,8 @@ public class ConversationsStateTest extends BasePlatformTestCase {
     assertThat(ConversationsState.getCurrentConversation()).isEqualTo(firstConversation);
     assertThat(service.getSortedConversations().size()).isEqualTo(1);
     assertThat(service.getSortedConversations())
-        .extracting("id")
-        .containsExactly(firstConversation.getId());
+        .extracting("localId")
+        .containsExactly(firstConversation.getLocalId());
   }
 
   public void testClearAllConversations() {


### PR DESCRIPTION
Changing the name here clarifies the code to indicate that a Conversation's 'id' is a local one and not one provided by the users selected AI service.