### PR TITLE
Fix StreamParser with text-code-text message sequence

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/StreamParser.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/StreamParser.java
@@ -1,49 +1,26 @@
 package ee.carlrobert.codegpt.toolwindow.chat;
 
+import ee.carlrobert.codegpt.util.MarkdownUtils;
+
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class StreamParser {
 
-  private static final String CODE_BLOCK_STARTING_REGEX = "```[a-zA-Z]*\n";
-  private final StringBuilder messageBuilder = new StringBuilder();
-  private boolean isProcessingCode;
-
   public List<StreamParseResponse> parse(String message) {
-    messageBuilder.append(message);
+    var blocks = MarkdownUtils.splitCodeBlocks(message);
+    var ret = blocks.stream().map(block -> {
+      if (block.startsWith("```")) {
+        return new StreamParseResponse(StreamResponseType.CODE, block);
+      } else {
+        return new StreamParseResponse(StreamResponseType.TEXT, block);
+      }
+    }).toArray(StreamParseResponse[]::new);
 
-    Pattern pattern = Pattern.compile(CODE_BLOCK_STARTING_REGEX);
-    Matcher matcher = pattern.matcher(messageBuilder.toString());
-    if (!isProcessingCode && matcher.find()) {
-      isProcessingCode = true;
-
-      var startingIndex = messageBuilder.indexOf(matcher.group());
-      var prevMessage = messageBuilder.substring(0, startingIndex);
-      messageBuilder.delete(0, messageBuilder.indexOf(matcher.group()));
-
-      return List.of(
-          new StreamParseResponse(StreamResponseType.TEXT, prevMessage),
-          new StreamParseResponse(StreamResponseType.CODE, messageBuilder.toString()));
-    }
-
-    var endingIndex = messageBuilder.indexOf("```\n", 1);
-    if (isProcessingCode && endingIndex > 0) {
-      isProcessingCode = false;
-
-      var codeResponse = messageBuilder.substring(0, endingIndex + 3);
-      messageBuilder.delete(0, endingIndex + 3);
-
-      return List.of(
-          new StreamParseResponse(StreamResponseType.CODE, codeResponse),
-          new StreamParseResponse(StreamResponseType.TEXT, messageBuilder.toString()));
-    }
-
-    return List.of(new StreamParseResponse(isProcessingCode ? StreamResponseType.CODE : StreamResponseType.TEXT, messageBuilder.toString()));
+    return List.of(ret);
   }
 
   public void clear() {
-    messageBuilder.setLength(0);
-    isProcessingCode = false;
   }
 }


### PR DESCRIPTION
Current parsers can only support `code-text`, `text-code`, `text`, `code`.

The following message(`text-code-text`) will be treated as text and will cause the HeaderActions of the code fragment not to be displayed.

````
foo
```
ls -la
```
bar
````

Switching to split markdown blocks with `MarkdownUtils.splitCodeBlocks` that are consistent with usage in the `ChatMessageResponseBody` would fix this kind of problem and ensure consistency throughout the project.