### PR TITLE
Fix memory leak in extensions

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/ServiceSelectionForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/ServiceSelectionForm.java
@@ -1,8 +1,8 @@
 package ee.carlrobert.codegpt.settings;
 
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.ui.ComboBox;
-import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.TitledSeparator;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBPasswordField;
@@ -31,6 +31,8 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 
 public class ServiceSelectionForm {
+
+  private final Disposable parentDisposable;
 
   private static final OpenAIChatCompletionModel[] DEFAULT_OPENAI_MODELS = new OpenAIChatCompletionModel[] {
       OpenAIChatCompletionModel.GPT_3_5,
@@ -67,7 +69,8 @@ public class ServiceSelectionForm {
   private final JPanel youServiceSectionPanel;
   private final JBCheckBox displayWebSearchResultsCheckBox;
 
-  public ServiceSelectionForm(SettingsState settings) {
+  public ServiceSelectionForm(Disposable parentDisposable, SettingsState settings) {
+    this.parentDisposable = parentDisposable;
     var openAISettings = OpenAISettingsState.getInstance();
     var azureSettings = AzureSettingsState.getInstance();
     openAIApiKeyField = new JBPasswordField();
@@ -233,7 +236,7 @@ public class ServiceSelectionForm {
 
   private JPanel createYouServiceSectionPanel() {
     return FormBuilder.createFormBuilder()
-        .addComponent(new YouServiceSelectionPanel(Disposer.newDisposable()))
+        .addComponent(new YouServiceSelectionPanel(parentDisposable))
         .addComponent(new TitledSeparator("Chat Preferences"))
         .addComponent(withEmptyLeftBorder(displayWebSearchResultsCheckBox))
         .getPanel();

--- a/src/main/java/ee/carlrobert/codegpt/settings/SettingsComponent.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/SettingsComponent.java
@@ -18,7 +18,7 @@ public class SettingsComponent {
   private final YouServiceSelectionPanel youServiceSelectionPanel;
 
   public SettingsComponent(Disposable parentDisposable, SettingsState settings) {
-    serviceSelectionForm = new ServiceSelectionForm(settings);
+    serviceSelectionForm = new ServiceSelectionForm(parentDisposable, settings);
     displayNameField = new JBTextField(settings.getDisplayName(), 20);
     youServiceSelectionPanel = new YouServiceSelectionPanel(parentDisposable);
     mainPanel = FormBuilder.createFormBuilder()

--- a/src/main/java/ee/carlrobert/codegpt/settings/SettingsConfigurable.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/SettingsConfigurable.java
@@ -2,6 +2,7 @@ package ee.carlrobert.codegpt.settings;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.util.Disposer;
 import ee.carlrobert.codegpt.CodeGPTBundle;
 import ee.carlrobert.codegpt.conversations.ConversationsState;
 import ee.carlrobert.codegpt.credentials.AzureCredentialsManager;
@@ -16,7 +17,9 @@ import javax.swing.JComponent;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
-public class SettingsConfigurable implements Configurable, Disposable {
+public class SettingsConfigurable implements Configurable {
+
+  private Disposable parentDisposable;
 
   private SettingsComponent settingsComponent;
 
@@ -35,7 +38,8 @@ public class SettingsConfigurable implements Configurable, Disposable {
   @Override
   public JComponent createComponent() {
     var settings = SettingsState.getInstance();
-    settingsComponent = new SettingsComponent(this, settings);
+    parentDisposable = Disposer.newDisposable();
+    settingsComponent = new SettingsComponent(parentDisposable, settings);
     return settingsComponent.getPanel();
   }
 
@@ -109,11 +113,10 @@ public class SettingsConfigurable implements Configurable, Disposable {
 
   @Override
   public void disposeUIResources() {
+    if (parentDisposable != null) {
+      Disposer.dispose(parentDisposable);
+    }
     settingsComponent = null;
-  }
-
-  @Override
-  public void dispose() {
   }
 
   private boolean isServiceChanged(

--- a/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationConfigurable.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationConfigurable.java
@@ -2,13 +2,16 @@ package ee.carlrobert.codegpt.settings.configuration;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.util.Disposer;
 import ee.carlrobert.codegpt.CodeGPTBundle;
 import ee.carlrobert.codegpt.actions.editor.EditorActionsUtil;
 import javax.swing.JComponent;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
-public class ConfigurationConfigurable implements Configurable, Disposable {
+public class ConfigurationConfigurable implements Configurable {
+
+  private Disposable parentDisposable;
 
   private ConfigurationComponent configurationComponent;
 
@@ -22,7 +25,8 @@ public class ConfigurationConfigurable implements Configurable, Disposable {
   @Override
   public JComponent createComponent() {
     var configuration = ConfigurationState.getInstance();
-    configurationComponent = new ConfigurationComponent(this, configuration);
+    parentDisposable = Disposer.newDisposable();
+    configurationComponent = new ConfigurationComponent(parentDisposable, configuration);
     return configurationComponent.getPanel();
   }
 
@@ -60,10 +64,9 @@ public class ConfigurationConfigurable implements Configurable, Disposable {
 
   @Override
   public void disposeUIResources() {
+    if (parentDisposable != null) {
+      Disposer.dispose(parentDisposable);
+    }
     configurationComponent = null;
-  }
-
-  @Override
-  public void dispose() {
   }
 }


### PR DESCRIPTION
Currently the following error occurs when compiling the plugin.

```
Memory leak detected: 'ee.carlrobert.codegpt.settings.SettingsConfigurable@4bcf0b26' (class ee.carlrobert.codegpt.settings.SettingsConfigurable) was registered in Disposer as a child of 'ROOT_DISPOSABLE' (class com.intellij.openapi.util.Disposer$2) but wasn't disposed.
Register it with a proper parentDisposable or ensure that it's always disposed by direct Disposer.dispose call.
See https://jetbrains.org/intellij/sdk/docs/basics/disposers.html for more details.
```

According to the [documentation](https://plugins.jetbrains.com/docs/intellij/disposers.html#automatically-disposed-objects), extensions registered in `plugin.xml` are not automatically disposed causing this error.

So defining [a disposable parent](https://plugins.jetbrains.com/docs/intellij/disposers.html#choosing-a-disposable-parent) and disposing it in `disposeUIResources` should fix this error.