### PR TITLE
Set line wrap style to be wrapped at word boundaries

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/components/UserPromptTextArea.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/components/UserPromptTextArea.java
@@ -54,6 +54,7 @@ public class UserPromptTextArea extends JPanel {
     textArea.setOpaque(false);
     textArea.setBackground(BACKGROUND_COLOR);
     textArea.setLineWrap(true);
+    textArea.setWrapStyleWord(true);
     textArea.getEmptyText().setText("Ask me anything");
     textArea.setBorder(JBUI.Borders.empty(8, 4));
     var input = textArea.getInputMap();


### PR DESCRIPTION
Issue #174 fixed.

before:
![20231010-210621@2x](https://github.com/carlrobertoh/CodeGPT/assets/8295052/591abf31-2a5f-4b90-b3a3-389743e7845e)
after:
![20231010-210651@2x](https://github.com/carlrobertoh/CodeGPT/assets/8295052/a63ae25a-a1e9-4af1-8196-b484e667ddb8)
