### PR TITLE
Local LLM: Use `OSProcessHandler.Silent` intead of `OSProcessHandler`…

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerAgent.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerAgent.java
@@ -78,7 +78,7 @@ public final class LlamaServerAgent implements Disposable {
       public void processTerminated(@NotNull ProcessEvent event) {
         try {
           serverProgressPanel.updateText("Booting up server...");
-          startServerProcessHandler = new OSProcessHandler(
+          startServerProcessHandler = new OSProcessHandler.Silent(
               getServerCommandLine(modelPath, contextLength, port));
           startServerProcessHandler.addProcessListener(
               getProcessListener(port, serverProgressPanel, onSuccess));


### PR DESCRIPTION
If after several minutes of inactivity you send a message to the chat, the plugin crashes. The logs contain the following:
```
2023-11-22 16:12:33,346 [ 317844]   WARN - #c.i.e.p.BaseOSProcessHandler - Process hasn't generated any output for a long time.
If it's a long-running mostly idle daemon process, consider overriding OSProcessHandler#readerOptions with 'BaseOutputReader.Options.forMostlySilentProcess()' to reduce CPU usage.
Command line: ./server -m /home/user/.codegpt/models/gguf/codellama-7b-instruct.Q4_K_M.gguf -c 2048 --port 39193 -t 20
java.lang.Throwable: Process creation:
	at com.intellij.execution.process.BaseOSProcessHandler.<init>(BaseOSProcessHandler.java:33)
	at com.intellij.execution.process.OSProcessHandler.<init>(OSProcessHandler.java:45)
	at ee.carlrobert.codegpt.completions.llama.LlamaServerAgent$1.processTerminated(LlamaServerAgent.java:90)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.intellij.execution.process.ProcessHandler$2.invoke(ProcessHandler.java:248)
	at jdk.proxy2/jdk.proxy2.$Proxy53.processTerminated(Unknown Source)
```
The IDE kills the server process.
To prevent this from happening, you must use the `OSProcessHandler.Silent` class to start the `llama.cpp` server.
This pull request contains the relevant changes.