### PR TITLE
Local LLM: Added empty check for `Additional parameters` field

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/service/LlamaServiceSelectionForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/LlamaServiceSelectionForm.java
@@ -23,6 +23,7 @@ import ee.carlrobert.codegpt.util.OverlayUtil;
 import java.awt.BorderLayout;
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -106,6 +107,9 @@ public class LlamaServiceSelectionForm extends JPanel {
   }
 
   public List<String> getListOfAdditionalParameters() {
+    if (additionalParametersField.getText().trim().isEmpty()) {
+      return Collections.emptyList();
+    }
     var parameters = additionalParametersField.getText().split(",");
     return Arrays.stream(parameters)
         .map(String::trim)


### PR DESCRIPTION
After adding the **Additional parameters** field, a problem arose with running local models. The problem is that if the **Additional parameters** field is left empty, then an empty parameter is added to the command line. It looks like this:
```./server -m /home/user/path/to/model/codellama-13b-instruct.Q4_K_M.gguf -c 2048 --port 39193 -t 20 ""```
Pay attention to the end of the line: `""`
Thus, the server does not start and on the screen we see the error: **Server Terminated**
This pull request fixes this issue.