### PR TITLE
fix: switch enabled state of custom model settings

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/service/LlamaModelPreferencesForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/LlamaModelPreferencesForm.java
@@ -160,6 +160,8 @@ public class LlamaModelPreferencesForm {
     modelComboBox.setEnabled(enabled);
     modelSizeComboBox.setEnabled(enabled);
     huggingFaceModelComboBox.setEnabled(enabled);
+    promptTemplateComboBox.setEnabled(enabled);
+    browsableCustomModelTextField.setEnabled(enabled);
   }
 
   public TextFieldWithBrowseButton getBrowsableCustomModelTextField() {


### PR DESCRIPTION
The model path and prompt template settings were not being enabled / disabled when user starts or stops the server.