### PR TITLE
Add setting for custom LLama server executable

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerAgent.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerAgent.java
@@ -39,15 +39,19 @@ public final class LlamaServerAgent implements Disposable {
       Runnable onSuccess,
       Runnable onServerTerminated) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      try {
-        serverProgressPanel.updateText(
-            CodeGPTBundle.get("llamaServerAgent.buildingProject.description"));
-        makeProcessHandler = new OSProcessHandler(getMakeCommandLinde());
-        makeProcessHandler.addProcessListener(
-            getMakeProcessListener(params, serverProgressPanel, onSuccess, onServerTerminated));
-        makeProcessHandler.startNotify();
-      } catch (ExecutionException e) {
-        throw new RuntimeException(e);
+      if (!params.isUseCustomServer()) {
+        try {
+          serverProgressPanel.updateText(
+              CodeGPTBundle.get("llamaServerAgent.buildingProject.description"));
+          makeProcessHandler = new OSProcessHandler(getMakeCommandLinde());
+          makeProcessHandler.addProcessListener(
+              getMakeProcessListener(params, serverProgressPanel, onSuccess, onServerTerminated));
+          makeProcessHandler.startNotify();
+        } catch (ExecutionException e) {
+          throw new RuntimeException(e);
+        }
+      } else {
+        startServer(params, serverProgressPanel, onSuccess, onServerTerminated);
       }
     });
   }
@@ -79,21 +83,29 @@ public final class LlamaServerAgent implements Disposable {
 
       @Override
       public void processTerminated(@NotNull ProcessEvent event) {
-        try {
-          LOG.info("Booting up llama server");
-
-          serverProgressPanel.updateText(
-              CodeGPTBundle.get("llamaServerAgent.serverBootup.description"));
-          startServerProcessHandler = new OSProcessHandler.Silent(getServerCommandLine(params));
-          startServerProcessHandler.addProcessListener(
-              getProcessListener(params.getPort(), onSuccess, onServerTerminated));
-          startServerProcessHandler.startNotify();
-        } catch (ExecutionException ex) {
-          LOG.error("Unable to start llama server", ex);
-          throw new RuntimeException(ex);
-        }
+        startServer(params, serverProgressPanel, onSuccess, onServerTerminated);
       }
     };
+  }
+
+  private void startServer(
+      LlamaServerStartupParams params,
+      ServerProgressPanel serverProgressPanel,
+      Runnable onSuccess,
+      Runnable onServerTerminated) {
+    try {
+      LOG.info("Booting up llama server");
+
+      serverProgressPanel.updateText(
+          CodeGPTBundle.get("llamaServerAgent.serverBootup.description"));
+      startServerProcessHandler = new OSProcessHandler.Silent(getServerCommandLine(params));
+      startServerProcessHandler.addProcessListener(
+          getProcessListener(params.getPort(), onSuccess, onServerTerminated));
+      startServerProcessHandler.startNotify();
+    } catch (ExecutionException ex) {
+      LOG.error("Unable to start llama server", ex);
+      throw new RuntimeException(ex);
+    }
   }
 
   private ProcessListener getProcessListener(
@@ -152,8 +164,8 @@ public final class LlamaServerAgent implements Disposable {
 
   private GeneralCommandLine getServerCommandLine(LlamaServerStartupParams params) {
     GeneralCommandLine commandLine = new GeneralCommandLine().withCharset(StandardCharsets.UTF_8);
-    commandLine.setExePath("./server");
-    commandLine.withWorkDirectory(CodeGPTPlugin.getLlamaSourcePath());
+    commandLine.setExePath("./" + params.getServerFileName());
+    commandLine.withWorkDirectory(params.getServerDirectory());
     commandLine.addParameters(
         "-m", params.getModelPath(),
         "-c", String.valueOf(params.getContextLength()),

--- a/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerStartupParams.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerStartupParams.java
@@ -1,9 +1,12 @@
 package ee.carlrobert.codegpt.completions.llama;
 
+import java.io.File;
 import java.util.List;
 
 public class LlamaServerStartupParams {
 
+  private final String serverPath;
+  private final boolean useCustomServer;
   private final String modelPath;
   private final int contextLength;
   private final int threads;
@@ -11,16 +14,35 @@ public class LlamaServerStartupParams {
   private final List<String> additionalParameters;
 
   public LlamaServerStartupParams(
-      String modelPath,
+      String serverPath,
+      boolean useCustomServer, String modelPath,
       int contextLength,
       int threads,
       int port,
       List<String> additionalParameters) {
+    this.serverPath = serverPath;
+    this.useCustomServer = useCustomServer;
     this.modelPath = modelPath;
     this.contextLength = contextLength;
     this.threads = threads;
     this.port = port;
     this.additionalParameters = additionalParameters;
+  }
+
+  public String getServerPath() {
+    return serverPath;
+  }
+
+  public String getServerFileName() {
+    return serverPath.substring(serverPath.lastIndexOf(File.separator) + 1);
+  }
+
+  public String getServerDirectory() {
+    return serverPath.substring(0, serverPath.lastIndexOf(File.separator) + 1);
+  }
+
+  public boolean isUseCustomServer() {
+    return useCustomServer;
   }
 
   public String getModelPath() {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/LlamaModelPreferencesForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/LlamaModelPreferencesForm.java
@@ -1,5 +1,6 @@
 package ee.carlrobert.codegpt.settings.service;
 
+import static ee.carlrobert.codegpt.ui.UIUtil.createRadioButtonsPanel;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
@@ -151,7 +152,8 @@ public class LlamaModelPreferencesForm {
 
   public JPanel getForm() {
     JPanel finalPanel = new JPanel(new BorderLayout());
-    finalPanel.add(createRadioButtonsPanel(), BorderLayout.NORTH);
+    finalPanel.add(createRadioButtonsPanel(predefinedModelRadioButton, customModelRadioButton),
+        BorderLayout.NORTH);
     finalPanel.add(createFormPanelCards(), BorderLayout.CENTER);
     return finalPanel;
   }
@@ -225,20 +227,6 @@ public class LlamaModelPreferencesForm {
         cardLayout.show(formPanelCards, CUSTOM_MODEL_FORM_CARD_CODE));
 
     return formPanelCards;
-  }
-
-  private JPanel createRadioButtonsPanel() {
-    var buttonGroup = new ButtonGroup();
-    buttonGroup.add(predefinedModelRadioButton);
-    buttonGroup.add(customModelRadioButton);
-
-    var radioPanel = new JPanel();
-    radioPanel.setLayout(new BoxLayout(radioPanel, BoxLayout.PAGE_AXIS));
-    radioPanel.add(predefinedModelRadioButton);
-    radioPanel.add(Box.createVerticalStrut(4));
-    radioPanel.add(customModelRadioButton);
-    radioPanel.add(Box.createVerticalStrut(8));
-    return radioPanel;
   }
 
   private JPanel createCustomModelForm() {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/ServiceSelectionForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/ServiceSelectionForm.java
@@ -432,4 +432,20 @@ public class ServiceSelectionForm {
   public void setAdditionalParameters(String additionalParameters) {
     llamaServiceSectionPanel.setAdditionalParameters(additionalParameters);
   }
+
+  public void setUseCustomLlamaServer(boolean useCustomLlamaServer) {
+    llamaServiceSectionPanel.setIsUseCustomServer(useCustomLlamaServer);
+  }
+
+  public boolean isUseCustomLlamaServer() {
+    return llamaServiceSectionPanel.isUseCustomServer();
+  }
+
+  public void setCustomLlamaServerPath(String serverPath) {
+    llamaServiceSectionPanel.setCustomServerPath(serverPath);
+  }
+
+  public String getCustomLlamaServerPath() {
+    return llamaServiceSectionPanel.getCustomServerPath();
+  }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/state/LlamaSettingsState.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/state/LlamaSettingsState.java
@@ -17,6 +17,8 @@ public class LlamaSettingsState implements PersistentStateComponent<LlamaSetting
 
   private boolean useCustomModel;
   private String customLlamaModelPath = "";
+  private boolean useCustomServer;
+  private String customLlamaServerPath = "";
   private HuggingFaceModel huggingFaceModel = HuggingFaceModel.CODE_LLAMA_7B_Q4;
   private PromptTemplate promptTemplate = PromptTemplate.LLAMA;
   private Integer serverPort = getRandomAvailablePortOrDefault();
@@ -51,6 +53,8 @@ public class LlamaSettingsState implements PersistentStateComponent<LlamaSetting
     return serverPort != serviceSelectionForm.getLlamaServerPort()
         || contextSize != serviceSelectionForm.getContextSize()
         || threads != serviceSelectionForm.getThreads()
+        || useCustomServer != serviceSelectionForm.isUseCustomLlamaServer()
+        || !customLlamaServerPath.equals(serviceSelectionForm.getCustomLlamaServerPath())
         || !additionalParameters.equals(serviceSelectionForm.getAdditionalParameters())
         || huggingFaceModel != modelPreferencesForm.getSelectedModel()
         || topK != requestPreferencesForm.getTopK()
@@ -76,6 +80,8 @@ public class LlamaSettingsState implements PersistentStateComponent<LlamaSetting
     serverPort = serviceSelectionForm.getLlamaServerPort();
     contextSize = serviceSelectionForm.getContextSize();
     threads = serviceSelectionForm.getThreads();
+    useCustomServer = serviceSelectionForm.isUseCustomLlamaServer();
+    customLlamaServerPath = serviceSelectionForm.getCustomLlamaServerPath();
     additionalParameters = serviceSelectionForm.getAdditionalParameters();
   }
 
@@ -93,7 +99,25 @@ public class LlamaSettingsState implements PersistentStateComponent<LlamaSetting
     serviceSelectionForm.setLlamaServerPort(serverPort);
     serviceSelectionForm.setContextSize(contextSize);
     serviceSelectionForm.setThreads(threads);
+    serviceSelectionForm.setUseCustomLlamaServer(useCustomServer);
+    serviceSelectionForm.setCustomLlamaServerPath(customLlamaServerPath);
     serviceSelectionForm.setAdditionalParameters(additionalParameters);
+  }
+
+  public boolean isUseCustomServer() {
+    return useCustomServer;
+  }
+
+  public void setUseCustomServer(boolean useCustomServer) {
+    this.useCustomServer = useCustomServer;
+  }
+
+  public String getCustomLlamaServerPath() {
+    return customLlamaServerPath;
+  }
+
+  public void setCustomLlamaServerPath(String customLlamaServerPath) {
+    this.customLlamaServerPath = customLlamaServerPath;
   }
 
   public boolean isUseCustomModel() {

--- a/src/main/java/ee/carlrobert/codegpt/ui/UIUtil.java
+++ b/src/main/java/ee/carlrobert/codegpt/ui/UIUtil.java
@@ -6,6 +6,7 @@ import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.roots.ui.componentsList.components.ScrollablePanel;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.ScrollPaneFactory;
+import com.intellij.ui.components.JBRadioButton;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UI;
@@ -14,6 +15,9 @@ import java.awt.Dimension;
 import java.net.URISyntaxException;
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -103,6 +107,19 @@ public class UIUtil {
     textArea.getInputMap().put(KeyStroke.getKeyStroke("shift ENTER"), "insert-break");
     textArea.getInputMap().put(KeyStroke.getKeyStroke("ENTER"), "text-submit");
     textArea.getActionMap().put("text-submit", onSubmit);
+  }
+
+  public static JPanel createRadioButtonsPanel(JBRadioButton... radioButtons) {
+    var buttonGroup = new ButtonGroup();
+    var radioPanel = new JPanel();
+    radioPanel.setLayout(new BoxLayout(radioPanel, BoxLayout.PAGE_AXIS));
+    for (int i = 0; i < radioButtons.length; i++) {
+      JBRadioButton radioButton = radioButtons[i];
+      buttonGroup.add(radioButton);
+      radioPanel.add(radioButton);
+      radioPanel.add(Box.createVerticalStrut(i == radioButtons.length - 1 ? 8 : 4));
+    }
+    return radioPanel;
   }
 }
 

--- a/src/main/resources/messages/codegpt.properties
+++ b/src/main/resources/messages/codegpt.properties
@@ -40,6 +40,8 @@ settingsConfigurable.service.llama.quantization.label=Quantization:
 settingsConfigurable.service.llama.quantization.comment=Quantization is a technique to reduce the computational and memory costs of running inference. <a href="https://huggingface.co/docs/optimum/concept_guides/quantization">Learn more</a>
 settingsConfigurable.service.llama.customModelPath.label=Model path:
 settingsConfigurable.service.llama.customModelPath.comment=Only .gguf files are supported
+settingsConfigurable.service.llama.customServerPath.label=Server path:
+settingsConfigurable.service.llama.customServerPath.comment=Precompiled executable llama-cpp server, only .exe (Windows) or executable File (Linux) are supported
 settingsConfigurable.service.llama.promptTemplate.comment=Choose the template to use during interactions with the language model. Make sure it matches the custom model you're working with.
 settingsConfigurable.service.llama.downloadModelLink.label=Download Model
 settingsConfigurable.service.llama.cancelDownloadLink.label=Cancel Downloading


### PR DESCRIPTION
Fixes #335 by adding new option in the settings to use a custom pre-compiled LLama Server:
![image](https://github.com/carlrobertoh/CodeGPT/assets/39240633/01160107-343e-4d62-9cce-094f52dc218c)

When `use custom-server` is selected it will run the configured custom server without compiling.