### PR TITLE
feat: Use /v1/chat/completions for OpenAI code-completions

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestProvider.java
@@ -2,8 +2,12 @@ package ee.carlrobert.codegpt.codecompletions;
 
 import ee.carlrobert.codegpt.completions.llama.LlamaModel;
 import ee.carlrobert.codegpt.settings.service.llama.LlamaSettings;
+import ee.carlrobert.codegpt.settings.service.openai.OpenAISettings;
+import ee.carlrobert.codegpt.settings.service.openai.OpenAISettingsState;
 import ee.carlrobert.llm.client.llama.completion.LlamaCompletionRequest;
-import ee.carlrobert.llm.client.openai.completion.request.OpenAITextCompletionRequest;
+import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionMessage;
+import ee.carlrobert.llm.client.openai.completion.request.OpenAIChatCompletionRequest;
+import java.util.List;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -17,12 +21,17 @@ public class CodeCompletionRequestProvider {
     this.details = details;
   }
 
-  public OpenAITextCompletionRequest buildOpenAIRequest() {
-    return new OpenAITextCompletionRequest.Builder(details.getPrefix())
-        .setSuffix(details.getSuffix())
+  public OpenAIChatCompletionRequest buildOpenAIRequest() {
+    String prompt = InfillPromptTemplate.OPENAI.buildPrompt(details.getPrefix(),
+        details.getSuffix());
+    OpenAISettingsState settings = OpenAISettings.getCurrentState();
+    return new OpenAIChatCompletionRequest.Builder(
+        List.of(new OpenAIChatCompletionMessage("user", prompt)))
+        .setModel(settings.getModel())
         .setStream(true)
         .setMaxTokens(MAX_TOKENS)
         .setTemperature(0.1)
+        .setOverriddenPath(settings.isUsingCustomPath() ? settings.getPath() : null)
         .build();
   }
 

--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
@@ -78,7 +78,7 @@ public final class CompletionRequestService {
     switch (GeneralSettings.getCurrentState().getSelectedService()) {
       case OPENAI:
         return CompletionClientProvider.getOpenAIClient()
-            .getCompletionAsync(requestProvider.buildOpenAIRequest(), eventListener);
+            .getChatCompletionAsync(requestProvider.buildOpenAIRequest(), eventListener);
       case LLAMA_CPP:
         return CompletionClientProvider.getLlamaClient()
             .getChatCompletionAsync(requestProvider.buildLlamaRequest(), eventListener);


### PR DESCRIPTION
Fixes #369.

This PR changes the Code-Completion for `OpenAI` ServiceType to use `/v1/chat/completions` instead of `/v1/completions`.
There is no `suffix` parameter for OpenAI Chat-Completions, therefore the FIM prompt template is used instead as a single "user" message.

Unfortunately the results dont look right to me just yet, I'm not sure why, here's an example: 
![image](https://github.com/carlrobertoh/CodeGPT/assets/39240633/c62a4132-9945-4d23-8dcf-c164abb10f73)
