### PR TITLE
Respect proxy settings for Azure Client

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
@@ -49,7 +49,7 @@ public class CompletionClientProvider {
     if (baseHost != null) {
       builder.setUrl(format(baseHost, params.getResourceName()));
     }
-    return builder.build();
+    return builder.build(getDefaultClientBuilder());
   }
 
   public static YouClient getYouClient() {


### PR DESCRIPTION
Currently proxy settings aren't considered when performing a request with the Azure service.