### PR TITLE
fix: completion prompt template for Deepseek Coder

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/codecompletions/InfillPromptTemplate.java
+++ b/src/main/java/ee/carlrobert/codegpt/codecompletions/InfillPromptTemplate.java
@@ -25,7 +25,7 @@ public enum InfillPromptTemplate {
       return format("<fim_prefix>%s<fim_suffix>%s<fim_middle>", prefix, suffix);
     }
   },
-  DEEPSEEK_CODER("DeepSeek Coder") {
+  DEEPSEEK_CODER("DeepSeek Coder", List.of("<|EOT|>")) {
     @Override
     public String buildPrompt(String prefix, String suffix) {
       return format("<｜fim▁begin｜>%s<｜fim▁hole｜>%s<｜fim▁end｜>", prefix, suffix);

--- a/src/main/java/ee/carlrobert/codegpt/codecompletions/InfillPromptTemplate.java
+++ b/src/main/java/ee/carlrobert/codegpt/codecompletions/InfillPromptTemplate.java
@@ -28,7 +28,7 @@ public enum InfillPromptTemplate {
   DEEPSEEK_CODER("DeepSeek Coder") {
     @Override
     public String buildPrompt(String prefix, String suffix) {
-      return format("<|fim_begin|>%s<|fim_hole|>%s<|fim_end|>", prefix, suffix);
+      return format("<｜fim▁begin｜>%s<｜fim▁hole｜>%s<｜fim▁end｜>", prefix, suffix);
     }
   };
 


### PR DESCRIPTION
@carlrobertoh @PhilKes 
Fix completion prompt template for DeepSeek Coder.

'<|fim_begin|>' -> '<｜fim▁begin｜>', they are different. Which is why the outputs so bad.

Reference: https://github.com/deepseek-ai/DeepSeek-Coder

BTW, I tested it with the original version of DeepSeek Coder 6.7B and 33B, quantized models have accuracy loss.