### PR TITLE
bugfix: Allow single Java files to be added to context

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/ui/checkbox/PsiElementCheckboxTree.java
+++ b/src/main/java/ee/carlrobert/codegpt/ui/checkbox/PsiElementCheckboxTree.java
@@ -40,6 +40,9 @@ public class PsiElementCheckboxTree extends FileCheckboxTree {
   }
 
   private static CheckedTreeNode createNode(PsiElement element) {
+    if (element instanceof com.intellij.psi.PsiClass) {
+      element = element.getContainingFile();
+    }
     if (!(element instanceof PsiDirectory || element instanceof PsiFile)) {
       return null;
     }


### PR DESCRIPTION
[Solves this issue](https://github.com/carlrobertoh/CodeGPT/issues/342). It seems that single Java files are represented as PsiClass in the Psi hierarchy rather than PsiFile. The class has a method `getContainingFile` that resolves the file so I've simply delegated to that in these cases. 