### PR TITLE
fix: Catch AssertionError in countTokens()

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/EncodingManager.java
+++ b/src/main/java/ee/carlrobert/codegpt/EncodingManager.java
@@ -60,9 +60,10 @@ public final class EncodingManager {
 
   public int countTokens(String text) {
     try {
+      // #444: Cl100kParser.split() throws AssertionError "Input is not UTF-8: "
       return encoding.countTokens(text);
-    } catch (Exception ex) {
-      LOG.warn(ex);
+    } catch (Exception | Error ex) {
+      LOG.warn("Could not count tokens for: " + text, ex);
       return 0;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/carlrobertoh/CodeGPT/issues/444

Now countTokens() catches `Errors` too like such encoding errors `Input is not UTF-8: `.
Like with exceptions, they will be logged in idea.log and 0 will be used for this input text.