### PR TITLE
fix: Use correct setting for updates and screenshot checkboxes (#446)

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationComponent.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationComponent.java
@@ -112,10 +112,10 @@ public class ConfigurationComponent {
 
     checkForPluginUpdatesCheckBox = new JBCheckBox(
         CodeGPTBundle.get("configurationConfigurable.checkForPluginUpdates.label"),
-        configuration.isCheckForNewScreenshots());
+        configuration.isCheckForPluginUpdates());
     checkForNewScreenshotsCheckBox = new JBCheckBox(
         CodeGPTBundle.get("configurationConfigurable.checkForNewScreenshots.label"),
-        configuration.isCheckForPluginUpdates());
+        configuration.isCheckForNewScreenshots());
     openNewTabCheckBox = new JBCheckBox(
         CodeGPTBundle.get("configurationConfigurable.openNewTabCheckBox.label"),
         configuration.isCreateNewChatOnEachAction());


### PR DESCRIPTION
Settings for Updates and Screenshot checkboxes were mixed up internally