### PR TITLE
fix: Persist credentials (#411)

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionClientProvider.java
@@ -1,8 +1,9 @@
 package ee.carlrobert.codegpt.completions;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+
 import ee.carlrobert.codegpt.CodeGPTPlugin;
 import ee.carlrobert.codegpt.completions.you.YouUserManager;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey;
 import ee.carlrobert.codegpt.settings.advanced.AdvancedSettings;
 import ee.carlrobert.codegpt.settings.service.anthropic.AnthropicSettings;
@@ -21,12 +22,10 @@ import java.net.Proxy;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
-import org.jetbrains.annotations.Nullable;
 
 public class CompletionClientProvider {
 
-  private static @Nullable String getCredential(CredentialKey key) {
-    return CredentialsStore.INSTANCE.getCredential(key);
+  private CompletionClientProvider() {
   }
 
   public static OpenAIClient getOpenAIClient() {

--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestProvider.java
@@ -1,5 +1,6 @@
 package ee.carlrobert.codegpt.completions;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.CUSTOM_SERVICE_API_KEY;
 import static ee.carlrobert.codegpt.util.file.FileUtil.getResourceContent;
 import static java.lang.String.format;
@@ -16,7 +17,6 @@ import ee.carlrobert.codegpt.completions.llama.PromptTemplate;
 import ee.carlrobert.codegpt.conversations.Conversation;
 import ee.carlrobert.codegpt.conversations.ConversationsState;
 import ee.carlrobert.codegpt.conversations.message.Message;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.settings.GeneralSettings;
 import ee.carlrobert.codegpt.settings.IncludedFilesSettings;
 import ee.carlrobert.codegpt.settings.configuration.ConfigurationSettings;
@@ -213,7 +213,7 @@ public class CompletionRequestProvider {
       List<OpenAIChatCompletionMessage> messages,
       boolean streamRequest) {
     var requestBuilder = new Request.Builder().url(customConfiguration.getUrl().trim());
-    var credential = CredentialsStore.INSTANCE.getCredential(CUSTOM_SERVICE_API_KEY);
+    var credential = getCredential(CUSTOM_SERVICE_API_KEY);
     for (var entry : customConfiguration.getHeaders().entrySet()) {
       String value = entry.getValue();
       if (credential != null && value.contains("$CUSTOM_SERVICE_API_KEY")) {

--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsConfigurable.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsConfigurable.java
@@ -102,17 +102,17 @@ public class GeneralSettingsConfigurable implements Configurable {
     }
   }
 
-  private void applyOpenAISettings(OpenAISettingsForm form) {
+  public void applyOpenAISettings(OpenAISettingsForm form) {
     CredentialsStore.INSTANCE.setCredential(OPENAI_API_KEY, form.getApiKey());
     OpenAISettings.getInstance().loadState(form.getCurrentState());
   }
 
-  private void applyCustomOpenAISettings(CustomServiceForm form) {
+  public void applyCustomOpenAISettings(CustomServiceForm form) {
     CredentialsStore.INSTANCE.setCredential(CUSTOM_SERVICE_API_KEY, form.getApiKey());
     CustomServiceSettings.getInstance().loadState(form.getCurrentState());
   }
 
-  private void applyLlamaSettings(LlamaSettingsForm form) {
+  public void applyLlamaSettings(LlamaSettingsForm form) {
     CredentialsStore.INSTANCE.setCredential(
         LLAMA_API_KEY,
         form.getLlamaServerPreferencesForm().getApiKey());
@@ -120,16 +120,16 @@ public class GeneralSettingsConfigurable implements Configurable {
     LlamaSettings.getInstance().loadState(form.getCurrentState());
   }
 
-  private void applyYouSettings(YouSettingsForm form) {
+  public void applyYouSettings(YouSettingsForm form) {
     YouSettings.getInstance().loadState(form.getCurrentState());
   }
 
-  private void applyAnthropicSettings(AnthropicSettingsForm form) {
+  public void applyAnthropicSettings(AnthropicSettingsForm form) {
     CredentialsStore.INSTANCE.setCredential(ANTHROPIC_API_KEY, form.getApiKey());
     AnthropicSettings.getInstance().loadState(form.getCurrentState());
   }
 
-  private void applyAzureSettings(AzureSettingsForm form) {
+  public void applyAzureSettings(AzureSettingsForm form) {
     AzureSettings.getInstance().loadState(form.getCurrentState());
     CredentialsStore.INSTANCE.setCredential(AZURE_OPENAI_API_KEY, form.getApiKey());
     CredentialsStore.INSTANCE.setCredential(

--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsConfigurable.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsConfigurable.java
@@ -6,6 +6,7 @@ import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.A
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.CUSTOM_SERVICE_API_KEY;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.LLAMA_API_KEY;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.OPENAI_API_KEY;
+import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.YOU_ACCOUNT_PASSWORD;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.options.Configurable;
@@ -121,6 +122,7 @@ public class GeneralSettingsConfigurable implements Configurable {
   }
 
   public void applyYouSettings(YouSettingsForm form) {
+    CredentialsStore.INSTANCE.setCredential(YOU_ACCOUNT_PASSWORD, form.getPassword());
     YouSettings.getInstance().loadState(form.getCurrentState());
   }
 

--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsConfigurable.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsConfigurable.java
@@ -82,8 +82,9 @@ public class GeneralSettingsConfigurable implements Configurable {
     settings.setSelectedService(component.getSelectedService());
 
     var serviceSelectionForm = component.getServiceSelectionForm();
-    var openAISettingsForm = serviceSelectionForm.getOpenAISettingsForm();
-    applyOpenAISettings(openAISettingsForm);
+    final var modelChanged = !OpenAISettings.getCurrentState().getModel()
+            .equals(serviceSelectionForm.getOpenAISettingsForm().getModel());
+    applyOpenAISettings(serviceSelectionForm.getOpenAISettingsForm());
     applyCustomOpenAISettings(serviceSelectionForm.getCustomConfigurationSettingsForm());
     applyAnthropicSettings(serviceSelectionForm.getAnthropicSettingsForm());
     applyAzureSettings(serviceSelectionForm.getAzureSettingsForm());
@@ -91,8 +92,6 @@ public class GeneralSettingsConfigurable implements Configurable {
     applyLlamaSettings(serviceSelectionForm.getLlamaSettingsForm());
 
     var serviceChanged = component.getSelectedService() != settings.getSelectedService();
-    var modelChanged = !OpenAISettings.getCurrentState().getModel()
-        .equals(openAISettingsForm.getModel());
     if (serviceChanged || modelChanged) {
       resetActiveTab();
       if (serviceChanged) {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/ServiceSelectionForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/ServiceSelectionForm.java
@@ -25,8 +25,7 @@ public class ServiceSelectionForm {
 
   public ServiceSelectionForm(Disposable parentDisposable) {
     openAISettingsForm = new OpenAISettingsForm(OpenAISettings.getCurrentState());
-    customServiceForm = new CustomServiceForm(
-        CustomServiceSettings.getCurrentState());
+    customServiceForm = new CustomServiceForm(CustomServiceSettings.getCurrentState());
     anthropicSettingsForm = new AnthropicSettingsForm(AnthropicSettings.getCurrentState());
     azureSettingsForm = new AzureSettingsForm(AzureSettings.getCurrentState());
     youSettingsForm = new YouSettingsForm(YouSettings.getCurrentState(), parentDisposable);

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettings.java
@@ -1,11 +1,12 @@
 package ee.carlrobert.codegpt.settings.service.anthropic;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.ANTHROPIC_API_KEY;
+
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
-import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,8 +36,6 @@ public class AnthropicSettings implements PersistentStateComponent<AnthropicSett
 
   public boolean isModified(AnthropicSettingsForm form) {
     return !form.getCurrentState().equals(state)
-        || !StringUtils.equals(
-        form.getApiKey(),
-        CredentialsStore.INSTANCE.getCredential(CredentialKey.ANTHROPIC_API_KEY));
+            || !StringUtils.equals(form.getApiKey(), getCredential(ANTHROPIC_API_KEY));
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/anthropic/AnthropicSettingsForm.java
@@ -1,5 +1,7 @@
 package ee.carlrobert.codegpt.settings.service.anthropic;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+import static ee.carlrobert.codegpt.credentials.Credential.sanitize;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.ANTHROPIC_API_KEY;
 import static ee.carlrobert.codegpt.ui.UIUtil.withEmptyLeftBorder;
 
@@ -9,7 +11,6 @@ import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.UI;
 import ee.carlrobert.codegpt.CodeGPTBundle;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.ui.UIUtil;
 import javax.swing.JPanel;
 import org.jetbrains.annotations.Nullable;
@@ -23,7 +24,7 @@ public class AnthropicSettingsForm {
   public AnthropicSettingsForm(AnthropicSettingsState settings) {
     apiKeyField = new JBPasswordField();
     apiKeyField.setColumns(30);
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(ANTHROPIC_API_KEY));
+    apiKeyField.setText(getCredential(ANTHROPIC_API_KEY));
     apiVersionField = new JBTextField(settings.getApiVersion(), 35);
     modelField = new JBTextField(settings.getModel(), 35);
   }
@@ -63,13 +64,16 @@ public class AnthropicSettingsForm {
 
   public void resetForm() {
     var state = AnthropicSettings.getCurrentState();
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(ANTHROPIC_API_KEY));
+    apiKeyField.setText(getCredential(ANTHROPIC_API_KEY));
     apiVersionField.setText(state.getApiVersion());
     modelField.setText(state.getModel());
   }
 
   public @Nullable String getApiKey() {
-    var apiKey = new String(apiKeyField.getPassword());
-    return apiKey.isEmpty() ? null : apiKey;
+    return sanitize(new String(apiKeyField.getPassword()));
+  }
+
+  public JBPasswordField getApiKeyField() {
+    return apiKeyField;
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/azure/AzureSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/azure/AzureSettings.java
@@ -1,5 +1,6 @@
 package ee.carlrobert.codegpt.settings.service.azure;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.AZURE_ACTIVE_DIRECTORY_TOKEN;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.AZURE_OPENAI_API_KEY;
 
@@ -7,7 +8,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,10 +38,7 @@ public class AzureSettings implements PersistentStateComponent<AzureSettingsStat
   public boolean isModified(AzureSettingsForm form) {
     return !form.getCurrentState().equals(state)
         || !StringUtils.equals(
-        form.getActiveDirectoryToken(),
-        CredentialsStore.INSTANCE.getCredential(AZURE_ACTIVE_DIRECTORY_TOKEN))
-        || !StringUtils.equals(
-        form.getApiKey(),
-        CredentialsStore.INSTANCE.getCredential(AZURE_OPENAI_API_KEY));
+        form.getActiveDirectoryToken(), getCredential(AZURE_ACTIVE_DIRECTORY_TOKEN))
+        || !StringUtils.equals(form.getApiKey(), getCredential(AZURE_OPENAI_API_KEY));
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/azure/AzureSettingsForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/azure/AzureSettingsForm.java
@@ -1,5 +1,9 @@
 package ee.carlrobert.codegpt.settings.service.azure;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+import static ee.carlrobert.codegpt.credentials.Credential.sanitize;
+import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.AZURE_ACTIVE_DIRECTORY_TOKEN;
+import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.AZURE_OPENAI_API_KEY;
 import static ee.carlrobert.codegpt.ui.UIUtil.withEmptyLeftBorder;
 
 import com.intellij.ui.TitledSeparator;
@@ -9,8 +13,6 @@ import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.UI;
 import ee.carlrobert.codegpt.CodeGPTBundle;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
-import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey;
 import java.util.List;
 import java.util.Map;
 import javax.swing.ButtonGroup;
@@ -38,16 +40,14 @@ public class AzureSettingsForm {
         settings.isUseAzureActiveDirectoryAuthentication());
     azureApiKeyField = new JBPasswordField();
     azureApiKeyField.setColumns(30);
-    azureApiKeyField.setText(
-        CredentialsStore.INSTANCE.getCredential(CredentialKey.AZURE_OPENAI_API_KEY));
+    azureApiKeyField.setText(getCredential(AZURE_OPENAI_API_KEY));
     azureApiKeyFieldPanel = UI.PanelFactory.panel(azureApiKeyField)
         .withLabel(CodeGPTBundle.get("settingsConfigurable.shared.apiKey.label"))
         .resizeX(false)
         .createPanel();
     azureActiveDirectoryTokenField = new JBPasswordField();
     azureActiveDirectoryTokenField.setColumns(30);
-    azureActiveDirectoryTokenField.setText(
-        CredentialsStore.INSTANCE.getCredential(CredentialKey.AZURE_ACTIVE_DIRECTORY_TOKEN));
+    azureActiveDirectoryTokenField.setText(getCredential(AZURE_ACTIVE_DIRECTORY_TOKEN));
     azureActiveDirectoryTokenFieldPanel = UI.PanelFactory.panel(azureActiveDirectoryTokenField)
         .withLabel(CodeGPTBundle.get("settingsConfigurable.service.azure.bearerToken.label"))
         .resizeX(false)
@@ -119,10 +119,8 @@ public class AzureSettingsForm {
 
   public void resetForm() {
     var state = AzureSettings.getCurrentState();
-    azureApiKeyField.setText(
-        CredentialsStore.INSTANCE.getCredential(CredentialKey.AZURE_OPENAI_API_KEY));
-    azureActiveDirectoryTokenField.setText(
-        CredentialsStore.INSTANCE.getCredential(CredentialKey.AZURE_ACTIVE_DIRECTORY_TOKEN));
+    azureApiKeyField.setText(getCredential(AZURE_OPENAI_API_KEY));
+    azureActiveDirectoryTokenField.setText(getCredential(AZURE_ACTIVE_DIRECTORY_TOKEN));
     useAzureApiKeyAuthenticationRadioButton.setSelected(state.isUseAzureApiKeyAuthentication());
     useAzureActiveDirectoryAuthenticationRadioButton.setSelected(
         state.isUseAzureActiveDirectoryAuthentication());
@@ -132,16 +130,19 @@ public class AzureSettingsForm {
   }
 
   public @Nullable String getActiveDirectoryToken() {
-    var activeDirToken = new String(azureActiveDirectoryTokenField.getPassword());
-    if (activeDirToken.isEmpty()) {
-      return null;
-    }
-    return activeDirToken;
+    return sanitize(new String(azureActiveDirectoryTokenField.getPassword()));
+  }
+
+  public JBPasswordField getActiveDirectoryTokenField() {
+    return azureActiveDirectoryTokenField;
   }
 
   public @Nullable String getApiKey() {
-    var apiKey = new String(azureApiKeyField.getPassword());
-    return apiKey.isEmpty() ? null : apiKey;
+    return sanitize(new String(azureApiKeyField.getPassword()));
+  }
+
+  public JBPasswordField getApiKeyField() {
+    return azureApiKeyField;
   }
 
   private void registerPanelsVisibility(AzureSettingsState azureSettings) {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/custom/CustomServiceForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/custom/CustomServiceForm.java
@@ -1,5 +1,7 @@
 package ee.carlrobert.codegpt.settings.service.custom;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+import static ee.carlrobert.codegpt.credentials.Credential.sanitize;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.CUSTOM_SERVICE_API_KEY;
 import static ee.carlrobert.codegpt.ui.UIUtil.withEmptyLeftBorder;
 
@@ -19,7 +21,6 @@ import ee.carlrobert.codegpt.completions.CompletionRequestProvider;
 import ee.carlrobert.codegpt.completions.CompletionRequestService;
 import ee.carlrobert.codegpt.conversations.Conversation;
 import ee.carlrobert.codegpt.conversations.message.Message;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.ui.OverlayUtil;
 import ee.carlrobert.codegpt.ui.UIUtil;
 import ee.carlrobert.llm.client.openai.completion.ErrorDetails;
@@ -47,7 +48,7 @@ public class CustomServiceForm {
   public CustomServiceForm(CustomServiceSettingsState settings) {
     apiKeyField = new JBPasswordField();
     apiKeyField.setColumns(30);
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(CUSTOM_SERVICE_API_KEY));
+    apiKeyField.setText(getCredential(CUSTOM_SERVICE_API_KEY));
     urlField = new JBTextField(settings.getUrl(), 30);
     tabbedPane = new CustomServiceFormTabbedPane(settings);
     testConnectionButton = new JButton(CodeGPTBundle.get(
@@ -100,8 +101,11 @@ public class CustomServiceForm {
   }
 
   public @Nullable String getApiKey() {
-    var apiKey = new String(apiKeyField.getPassword());
-    return apiKey.isEmpty() ? null : apiKey;
+    return sanitize(new String(apiKeyField.getPassword()));
+  }
+
+  public JBPasswordField getApiKeyField() {
+    return apiKeyField;
   }
 
   public CustomServiceSettingsState getCurrentState() {
@@ -115,7 +119,7 @@ public class CustomServiceForm {
 
   public void resetForm() {
     var state = CustomServiceSettings.getCurrentState();
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(CUSTOM_SERVICE_API_KEY));
+    apiKeyField.setText(getCredential(CUSTOM_SERVICE_API_KEY));
     urlField.setText(state.getUrl());
     templateComboBox.setSelectedItem(state.getTemplate());
     tabbedPane.setHeaders(state.getHeaders());

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/custom/CustomServiceSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/custom/CustomServiceSettings.java
@@ -1,12 +1,12 @@
 package ee.carlrobert.codegpt.settings.service.custom;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.CUSTOM_SERVICE_API_KEY;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,8 +38,6 @@ public class CustomServiceSettings implements PersistentStateComponent<CustomSer
 
   public boolean isModified(CustomServiceForm form) {
     return !form.getCurrentState().equals(state)
-        || !StringUtils.equals(
-        form.getApiKey(),
-        CredentialsStore.INSTANCE.getCredential(CUSTOM_SERVICE_API_KEY));
+            || !StringUtils.equals(form.getApiKey(), getCredential(CUSTOM_SERVICE_API_KEY));
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/llama/LlamaSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/llama/LlamaSettings.java
@@ -1,12 +1,12 @@
 package ee.carlrobert.codegpt.settings.service.llama;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.LLAMA_API_KEY;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.settings.service.llama.form.LlamaSettingsForm;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +39,6 @@ public class LlamaSettings implements PersistentStateComponent<LlamaSettingsStat
     return !form.getCurrentState().equals(state)
         || !StringUtils.equals(
         form.getLlamaServerPreferencesForm().getApiKey(),
-        CredentialsStore.INSTANCE.getCredential(LLAMA_API_KEY));
+        getCredential(LLAMA_API_KEY));
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/LlamaServerPreferencesForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/LlamaServerPreferencesForm.java
@@ -1,5 +1,7 @@
 package ee.carlrobert.codegpt.settings.service.llama.form;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+import static ee.carlrobert.codegpt.credentials.Credential.sanitize;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.LLAMA_API_KEY;
 import static ee.carlrobert.codegpt.ui.UIUtil.createComment;
 import static ee.carlrobert.codegpt.ui.UIUtil.createForm;
@@ -27,7 +29,6 @@ import ee.carlrobert.codegpt.completions.HuggingFaceModel;
 import ee.carlrobert.codegpt.completions.llama.LlamaServerAgent;
 import ee.carlrobert.codegpt.completions.llama.LlamaServerStartupParams;
 import ee.carlrobert.codegpt.completions.llama.PromptTemplate;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.settings.service.llama.LlamaSettingsState;
 import ee.carlrobert.codegpt.ui.OverlayUtil;
 import ee.carlrobert.codegpt.ui.UIUtil;
@@ -82,7 +83,7 @@ public class LlamaServerPreferencesForm {
     baseHostField = new JBTextField(settings.getBaseHost(), 30);
     apiKeyField = new JBPasswordField();
     apiKeyField.setColumns(30);
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(LLAMA_API_KEY));
+    apiKeyField.setText(getCredential(LLAMA_API_KEY));
 
     llamaModelPreferencesForm = new LlamaModelPreferencesForm();
     runLocalServerRadioButton = new JBRadioButton("Run local server",
@@ -126,7 +127,7 @@ public class LlamaServerPreferencesForm {
     additionalParametersField.setText(state.getAdditionalParameters());
     remotePromptTemplatePanel.setPromptTemplate(state.getRemoteModelPromptTemplate()); // ?
     infillPromptTemplatePanel.setPromptTemplate(state.getRemoteModelInfillPromptTemplate());
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(LLAMA_API_KEY));
+    apiKeyField.setText(getCredential(LLAMA_API_KEY));
   }
 
   public JComponent createUseExistingServerForm() {
@@ -249,7 +250,7 @@ public class LlamaServerPreferencesForm {
   private boolean validateCustomModelPath() {
     if (llamaModelPreferencesForm.isUseCustomLlamaModel()) {
       var customModelPath = llamaModelPreferencesForm.getCustomLlamaModelPath();
-      if (customModelPath == null || customModelPath.isEmpty()) {
+      if (customModelPath == null || customModelPath.isBlank()) {
         OverlayUtil.showBalloon(
             CodeGPTBundle.get("validation.error.fieldRequired"),
             MessageType.ERROR,
@@ -348,8 +349,11 @@ public class LlamaServerPreferencesForm {
   }
 
   public @Nullable String getApiKey() {
-    var apiKey = new String(apiKeyField.getPassword());
-    return apiKey.isEmpty() ? null : apiKey;
+    return sanitize(new String(apiKeyField.getPassword()));
+  }
+
+  public JBPasswordField getApiKeyField() {
+    return apiKeyField;
   }
 
   public InfillPromptTemplate getInfillPromptTemplate() {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/openai/OpenAISettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/openai/OpenAISettings.java
@@ -1,12 +1,12 @@
 package ee.carlrobert.codegpt.settings.service.openai;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.OPENAI_API_KEY;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,8 +36,6 @@ public class OpenAISettings implements PersistentStateComponent<OpenAISettingsSt
 
   public boolean isModified(OpenAISettingsForm form) {
     return !form.getCurrentState().equals(state)
-        || !StringUtils.equals(
-        form.getApiKey(),
-        CredentialsStore.INSTANCE.getCredential(OPENAI_API_KEY));
+        || !StringUtils.equals(form.getApiKey(), getCredential(OPENAI_API_KEY));
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/openai/OpenAISettingsForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/openai/OpenAISettingsForm.java
@@ -1,5 +1,7 @@
 package ee.carlrobert.codegpt.settings.service.openai;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+import static ee.carlrobert.codegpt.credentials.Credential.sanitize;
 import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.OPENAI_API_KEY;
 import static ee.carlrobert.codegpt.ui.UIUtil.withEmptyLeftBorder;
 
@@ -11,7 +13,6 @@ import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.UI;
 import ee.carlrobert.codegpt.CodeGPTBundle;
-import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.settings.service.CodeCompletionConfigurationForm;
 import ee.carlrobert.codegpt.ui.UIUtil;
 import ee.carlrobert.llm.client.openai.completion.OpenAIChatCompletionModel;
@@ -28,7 +29,7 @@ public class OpenAISettingsForm {
   public OpenAISettingsForm(OpenAISettingsState settings) {
     apiKeyField = new JBPasswordField();
     apiKeyField.setColumns(30);
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(OPENAI_API_KEY));
+    apiKeyField.setText(getCredential(OPENAI_API_KEY));
     organizationField = new JBTextField(settings.getOrganization(), 30);
     completionModelComboBox = new ComboBox<>(
         new EnumComboBoxModel<>(OpenAIChatCompletionModel.class));
@@ -66,8 +67,11 @@ public class OpenAISettingsForm {
   }
 
   public @Nullable String getApiKey() {
-    var apiKey = new String(apiKeyField.getPassword());
-    return apiKey.isEmpty() ? null : apiKey;
+    return sanitize(new String(apiKeyField.getPassword()));
+  }
+
+  public JBPasswordField getApiKeyField() {
+    return apiKeyField;
   }
 
   public String getModel() {
@@ -87,7 +91,7 @@ public class OpenAISettingsForm {
 
   public void resetForm() {
     var state = OpenAISettings.getCurrentState();
-    apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(OPENAI_API_KEY));
+    apiKeyField.setText(getCredential(OPENAI_API_KEY));
     completionModelComboBox.setSelectedItem(
         OpenAIChatCompletionModel.findByCode(state.getModel()));
     organizationField.setText(state.getOrganization());

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/you/YouSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/you/YouSettings.java
@@ -1,9 +1,13 @@
 package ee.carlrobert.codegpt.settings.service.you;
 
+import static ee.carlrobert.codegpt.credentials.Credential.getCredential;
+import static ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.YOU_ACCOUNT_PASSWORD;
+
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 @State(name = "CodeGPT_YouSettings", storages = @Storage("CodeGPT_YouSettings.xml"))
@@ -31,6 +35,7 @@ public class YouSettings implements PersistentStateComponent<YouSettingsState> {
   }
 
   public boolean isModified(YouSettingsForm form) {
-    return !form.getCurrentState().equals(state);
+    return !form.getCurrentState().equals(state)
+            || !StringUtils.equals(form.getPassword(), getCredential(YOU_ACCOUNT_PASSWORD));
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/you/YouSettingsForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/you/YouSettingsForm.java
@@ -252,14 +252,10 @@ public class YouSettingsForm extends JPanel {
   }
 
   class UserAuthenticationHandler implements AuthenticationHandler {
-
     @Override
     public void handleAuthenticated(YouAuthenticationResponse authenticationResponse) {
       SwingUtilities.invokeLater(() -> {
-        var email = emailField.getText();
-        var password = getPassword();
-        YouSettings.getCurrentState().setEmail(email);
-        CredentialsStore.INSTANCE.setCredential(YOU_ACCOUNT_PASSWORD, password);
+        YouSettings.getCurrentState().setEmail(emailField.getText());
         refreshView(createUserInformationPanel(authenticationResponse.data().user()));
       });
     }

--- a/src/main/kotlin/ee/carlrobert/codegpt/CodeGPTProjectActivity.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/CodeGPTProjectActivity.kt
@@ -12,9 +12,9 @@ import ee.carlrobert.codegpt.completions.you.auth.AuthenticationHandler
 import ee.carlrobert.codegpt.completions.you.auth.YouAuthenticationError
 import ee.carlrobert.codegpt.completions.you.auth.YouAuthenticationService
 import ee.carlrobert.codegpt.completions.you.auth.response.YouAuthenticationResponse
+import ee.carlrobert.codegpt.credentials.Credential.Companion.getCredential
 import ee.carlrobert.codegpt.credentials.CredentialsStore
 import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey
-import ee.carlrobert.codegpt.credentials.CredentialsStore.getCredential
 import ee.carlrobert.codegpt.settings.configuration.ConfigurationSettings
 import ee.carlrobert.codegpt.settings.service.you.YouSettings
 import ee.carlrobert.codegpt.toolwindow.chat.ui.textarea.AttachImageNotifier
@@ -48,7 +48,7 @@ class CodeGPTProjectActivity : ProjectActivity {
     private fun handleYouServiceAuthenticationAsync() {
         val settings = YouSettings.getCurrentState()
         val password = getCredential(CredentialKey.YOU_ACCOUNT_PASSWORD)
-        if (settings.email.isNotEmpty() && !password.isNullOrEmpty()) {
+        if (settings.email.isNotBlank() && !password.isNullOrBlank()) {
             YouAuthenticationService.getInstance()
                 .signInAsync(settings.email, password, object : AuthenticationHandler {
                     override fun handleAuthenticated(authenticationResponse: YouAuthenticationResponse) {

--- a/src/main/kotlin/ee/carlrobert/codegpt/credentials/Credential.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/credentials/Credential.kt
@@ -1,0 +1,35 @@
+package ee.carlrobert.codegpt.credentials
+
+import com.intellij.ide.passwordSafe.PasswordSafe
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey
+import ee.carlrobert.codegpt.credentials.CredentialsStore.credentialAttributes
+import java.util.Optional
+
+class Credential {
+  companion object {
+    /**
+     * Sanitized credential from in-memory store (not blank, otherwise null)
+     */
+    @JvmStatic
+    fun getCredential(key: CredentialKey): String? {
+      return sanitize(CredentialsStore.getCredential(key))
+    }
+
+    /**
+     * Sanitized password from persisted store (not blank, otherwise null)
+     */
+    @JvmStatic
+    fun getPassword(key: CredentialKey): String? {
+      return sanitize(PasswordSafe.instance.getPassword(credentialAttributes(key)))
+    }
+
+    /**
+     * Sanitized credential (not blank, otherwise null)
+     */
+    @JvmStatic
+    fun sanitize(credential: String?): String? {
+      return Optional.ofNullable(credential)
+        .filter(String::isNotBlank).orElse(null)
+    }
+  }
+}

--- a/src/main/kotlin/ee/carlrobert/codegpt/credentials/CredentialsStore.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/credentials/CredentialsStore.kt
@@ -3,26 +3,30 @@ package ee.carlrobert.codegpt.credentials
 import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.generateServiceName
 import com.intellij.ide.passwordSafe.PasswordSafe
+import ee.carlrobert.codegpt.credentials.Credential.Companion.getPassword
+import ee.carlrobert.codegpt.credentials.Credential.Companion.sanitize
 
 object CredentialsStore {
 
     private val credentialsMap = mutableMapOf<CredentialKey, String?>()
 
-    fun loadAll() {
-        CredentialKey.values().forEach {
-            val credentialAttributes = CredentialAttributes(generateServiceName("CodeGPT", it.name))
-            val password = PasswordSafe.instance.getPassword(credentialAttributes)
-            setCredential(it, password)
-        }
-    }
+    fun loadAll() = CredentialKey.entries.forEach { setCredential(it, getPassword(it), false) }
 
     fun getCredential(key: CredentialKey): String? = credentialsMap[key]
 
-    fun setCredential(key: CredentialKey, password: String?) {
-        credentialsMap[key] = password
+    fun setCredential(key: CredentialKey, password: String?) = setCredential(key, password, true)
+
+    fun isCredentialSet(key: CredentialKey): Boolean = !getCredential(key).isNullOrBlank()
+
+    private fun setCredential(key: CredentialKey, password: String?, persist: Boolean) {
+        credentialsMap[key] = sanitize(password)
+        if (persist) {
+            PasswordSafe.instance.setPassword(credentialAttributes(key), sanitize(password))
+        }
     }
 
-    fun isCredentialSet(key: CredentialKey): Boolean = !getCredential(key).isNullOrEmpty()
+    fun credentialAttributes(key: CredentialKey) =
+        CredentialAttributes(generateServiceName("CodeGPT", key.name))
 
     enum class CredentialKey {
         OPENAI_API_KEY,

--- a/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsFormTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsFormTest.kt
@@ -1,0 +1,292 @@
+package ee.carlrobert.codegpt.settings.state
+
+import com.intellij.openapi.Disposable
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import ee.carlrobert.codegpt.credentials.Credential.Companion.getCredential
+import ee.carlrobert.codegpt.credentials.Credential.Companion.getPassword
+import ee.carlrobert.codegpt.credentials.Credential.Companion.sanitize
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.ANTHROPIC_API_KEY
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.AZURE_ACTIVE_DIRECTORY_TOKEN
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.AZURE_OPENAI_API_KEY
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.CUSTOM_SERVICE_API_KEY
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.LLAMA_API_KEY
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.OPENAI_API_KEY
+import ee.carlrobert.codegpt.credentials.CredentialsStore.CredentialKey.YOU_ACCOUNT_PASSWORD
+import ee.carlrobert.codegpt.credentials.CredentialsStore.setCredential
+import ee.carlrobert.codegpt.settings.GeneralSettingsConfigurable
+import ee.carlrobert.codegpt.settings.service.anthropic.AnthropicSettings
+import ee.carlrobert.codegpt.settings.service.anthropic.AnthropicSettingsForm
+import ee.carlrobert.codegpt.settings.service.anthropic.AnthropicSettingsState
+import ee.carlrobert.codegpt.settings.service.azure.AzureSettings
+import ee.carlrobert.codegpt.settings.service.azure.AzureSettingsForm
+import ee.carlrobert.codegpt.settings.service.azure.AzureSettingsState
+import ee.carlrobert.codegpt.settings.service.custom.CustomServiceForm
+import ee.carlrobert.codegpt.settings.service.custom.CustomServiceSettings
+import ee.carlrobert.codegpt.settings.service.custom.CustomServiceSettingsState
+import ee.carlrobert.codegpt.settings.service.llama.LlamaSettings
+import ee.carlrobert.codegpt.settings.service.llama.LlamaSettingsState
+import ee.carlrobert.codegpt.settings.service.llama.form.LlamaSettingsForm
+import ee.carlrobert.codegpt.settings.service.openai.OpenAISettings
+import ee.carlrobert.codegpt.settings.service.openai.OpenAISettingsForm
+import ee.carlrobert.codegpt.settings.service.openai.OpenAISettingsState
+import ee.carlrobert.codegpt.settings.service.you.YouSettings
+import ee.carlrobert.codegpt.settings.service.you.YouSettingsForm
+import ee.carlrobert.codegpt.settings.service.you.YouSettingsState
+import org.assertj.core.api.Assertions.assertThat
+import java.util.stream.Stream
+
+class GeneralSettingsFormTest : BasePlatformTestCase() {
+
+  private val generalSettingsConfigurable = GeneralSettingsConfigurable()
+
+  fun testAnthropicSettingsApiKey() {
+    Stream.of("", "  ", " abc ", null).forEach { anthropicSettingsApiKey(it) }
+  }
+
+  fun testAzureSettingsApiKey() {
+    Stream.of("", "  ", " abc ", null).forEach { azureSettingsApiKey(it) }
+  }
+
+  fun testCustomSettingsApiKey() {
+    Stream.of("", "  ", " abc ", null).forEach { customSettingsApiKey(it) }
+  }
+
+  fun testLlamaSettingsApiKey() {
+    Stream.of("", "  ", " abc ", null).forEach { llamaSettingsApiKey(it) }
+  }
+
+  fun testOpenAISettingsApiKey() {
+    Stream.of("", "  ", " abc ", null).forEach { openAISettingsApiKey(it) }
+  }
+
+  fun testYouSettingsPassword() {
+    Stream.of("", "  ", " abc ", null).forEach { youSettingsApiPassword(it) }
+  }
+
+  private fun anthropicSettingsApiKey(apiKey: String?) {
+    assertThat(getCredential(ANTHROPIC_API_KEY)).isNotEqualTo(apiKey)
+
+    // new form reads from store
+    setCredential(ANTHROPIC_API_KEY, apiKey)
+    val expected = sanitize(apiKey)
+    assertThat(getPassword(ANTHROPIC_API_KEY)).isEqualTo(expected)
+    val form = AnthropicSettingsForm(AnthropicSettingsState())
+    assertThat(form.apiKey).isEqualTo(expected)
+
+    // reset form from store
+    setCredential(ANTHROPIC_API_KEY, "123")
+    assertThat(getPassword(ANTHROPIC_API_KEY)).isEqualTo("123")
+    val newState = AnthropicSettingsState()
+    AnthropicSettings.getInstance().loadState(newState)
+    assertThat(AnthropicSettings.getCurrentState()).isEqualTo(newState)
+    assertThat(form.apiKey).isEqualTo(expected)
+    form.resetForm()
+    assertThat(form.apiKey).isEqualTo("123")
+
+    // change text in form field only, not store
+    form.apiKeyField.text = "456"
+    assertThat(form.apiKey).isEqualTo("456")
+    assertThat(getPassword(ANTHROPIC_API_KEY)).isEqualTo("123")
+
+    // state is equal, but form is modified (password changed)
+    assertThat(AnthropicSettings.getCurrentState()).isEqualTo(form.currentState)
+    assertThat(AnthropicSettings.getInstance().isModified(form)).isTrue()
+
+    // apply form stores changed password
+    generalSettingsConfigurable.applyAnthropicSettings(form)
+    assertThat(getPassword(ANTHROPIC_API_KEY)).isEqualTo("456")
+  }
+
+  private fun azureSettingsApiKey(apiKey: String?) {
+    val activeDirectoryToken = apiKey
+    assertThat(getCredential(AZURE_OPENAI_API_KEY)).isNotEqualTo(apiKey)
+    assertThat(getCredential(AZURE_ACTIVE_DIRECTORY_TOKEN)).isNotEqualTo(activeDirectoryToken)
+
+    // new form reads from store
+    setCredential(AZURE_OPENAI_API_KEY, apiKey)
+    setCredential(AZURE_ACTIVE_DIRECTORY_TOKEN, activeDirectoryToken)
+    val expected = sanitize(apiKey)
+    val expectedToken = sanitize(activeDirectoryToken)
+    assertThat(getPassword(AZURE_OPENAI_API_KEY)).isEqualTo(expected)
+    assertThat(getPassword(AZURE_ACTIVE_DIRECTORY_TOKEN)).isEqualTo(expectedToken)
+    val form = AzureSettingsForm(AzureSettingsState())
+    assertThat(form.apiKey).isEqualTo(expected)
+    assertThat(form.activeDirectoryToken).isEqualTo(expectedToken)
+
+    // reset form from store
+    setCredential(AZURE_OPENAI_API_KEY, "123")
+    setCredential(AZURE_ACTIVE_DIRECTORY_TOKEN, "123b")
+    assertThat(getPassword(AZURE_OPENAI_API_KEY)).isEqualTo("123")
+    assertThat(getPassword(AZURE_ACTIVE_DIRECTORY_TOKEN)).isEqualTo("123b")
+    val newState = AzureSettingsState()
+    AzureSettings.getInstance().loadState(newState)
+    assertThat(AzureSettings.getCurrentState()).isEqualTo(newState)
+    assertThat(form.apiKey).isEqualTo(expected)
+    assertThat(form.activeDirectoryToken).isEqualTo(expectedToken)
+    form.resetForm()
+    assertThat(form.apiKey).isEqualTo("123")
+    assertThat(form.activeDirectoryToken).isEqualTo("123b")
+
+    // change text in form field only, not store
+    form.apiKeyField.text = "456"
+    form.activeDirectoryTokenField.text = "456b"
+    assertThat(form.apiKey).isEqualTo("456")
+    assertThat(form.activeDirectoryToken).isEqualTo("456b")
+    assertThat(getPassword(AZURE_OPENAI_API_KEY)).isEqualTo("123")
+    assertThat(getPassword(AZURE_ACTIVE_DIRECTORY_TOKEN)).isEqualTo("123b")
+
+    // state is equal, but form is modified (passwords changed)
+    assertThat(AzureSettings.getCurrentState()).isEqualTo(form.currentState)
+    assertThat(AzureSettings.getInstance().isModified(form)).isTrue()
+
+    // apply form stores changed passwords
+    generalSettingsConfigurable.applyAzureSettings(form)
+    assertThat(getPassword(AZURE_OPENAI_API_KEY)).isEqualTo("456")
+    assertThat(getPassword(AZURE_ACTIVE_DIRECTORY_TOKEN)).isEqualTo("456b")
+  }
+
+  private fun customSettingsApiKey(apiKey: String?) {
+    assertThat(getCredential(CUSTOM_SERVICE_API_KEY)).isNotEqualTo(apiKey)
+
+    // new form reads from store
+    setCredential(CUSTOM_SERVICE_API_KEY, apiKey)
+    val expected = sanitize(apiKey)
+    assertThat(getPassword(CUSTOM_SERVICE_API_KEY)).isEqualTo(expected)
+    val form = CustomServiceForm(CustomServiceSettingsState())
+    assertThat(form.apiKey).isEqualTo(expected)
+
+    // reset form from store
+    setCredential(CUSTOM_SERVICE_API_KEY, "123")
+    assertThat(getPassword(CUSTOM_SERVICE_API_KEY)).isEqualTo("123")
+    val newState = CustomServiceSettingsState()
+    CustomServiceSettings.getInstance().loadState(newState)
+    assertThat(CustomServiceSettings.getCurrentState()).isEqualTo(newState)
+    assertThat(form.apiKey).isEqualTo(expected)
+    form.resetForm()
+    assertThat(form.apiKey).isEqualTo("123")
+
+    // change text in form field only, not store
+    form.apiKeyField.text = "456"
+    assertThat(form.apiKey).isEqualTo("456")
+    assertThat(getPassword(CUSTOM_SERVICE_API_KEY)).isEqualTo("123")
+
+    // state is equal, but form is modified (password changed)
+    assertThat(CustomServiceSettings.getCurrentState()).isEqualTo(form.currentState)
+    assertThat(CustomServiceSettings.getInstance().isModified(form)).isTrue()
+
+    // apply form stores changed password
+    generalSettingsConfigurable.applyCustomOpenAISettings(form)
+    assertThat(getPassword(CUSTOM_SERVICE_API_KEY)).isEqualTo("456")
+  }
+
+  private fun llamaSettingsApiKey(apiKey: String?) {
+    assertThat(getCredential(LLAMA_API_KEY)).isNotEqualTo(apiKey)
+
+    // new form reads from store
+    setCredential(LLAMA_API_KEY, apiKey)
+    val expected = sanitize(apiKey)
+    assertThat(getPassword(LLAMA_API_KEY)).isEqualTo(expected)
+    val form = LlamaSettingsForm(LlamaSettingsState())
+    assertThat(form.llamaServerPreferencesForm.apiKey).isEqualTo(expected)
+
+    // reset form from store
+    setCredential(LLAMA_API_KEY, "123")
+    assertThat(getPassword(LLAMA_API_KEY)).isEqualTo("123")
+    val newState = LlamaSettingsState()
+    LlamaSettings.getInstance().loadState(newState)
+    assertThat(LlamaSettings.getCurrentState()).isEqualTo(newState)
+    assertThat(form.llamaServerPreferencesForm.apiKey).isEqualTo(expected)
+    form.llamaServerPreferencesForm.resetForm(newState)
+    assertThat(form.llamaServerPreferencesForm.apiKey).isEqualTo("123")
+
+    // change text in form field only, not store
+    form.llamaServerPreferencesForm.apiKeyField.text = "456"
+    assertThat(form.llamaServerPreferencesForm.apiKey).isEqualTo("456")
+    assertThat(getPassword(LLAMA_API_KEY)).isEqualTo("123")
+
+    // state is equal, but form is modified (password changed)
+    assertThat(LlamaSettings.getCurrentState()).isEqualTo(form.currentState)
+    assertThat(LlamaSettings.getInstance().isModified(form)).isTrue()
+
+    // apply form stores changed password
+    generalSettingsConfigurable.applyLlamaSettings(form)
+    assertThat(getPassword(LLAMA_API_KEY)).isEqualTo("456")
+  }
+
+  private fun openAISettingsApiKey(apiKey: String?) {
+    assertThat(getCredential(OPENAI_API_KEY)).isNotEqualTo(apiKey)
+
+    // new form reads from store
+    setCredential(OPENAI_API_KEY, apiKey)
+    val expected = sanitize(apiKey)
+    assertThat(getPassword(OPENAI_API_KEY)).isEqualTo(expected)
+    val form = OpenAISettingsForm(OpenAISettingsState())
+    assertThat(form.apiKey).isEqualTo(expected)
+
+    // reset form from store
+    setCredential(OPENAI_API_KEY, "123")
+    assertThat(getPassword(OPENAI_API_KEY)).isEqualTo("123")
+    val newState = OpenAISettingsState()
+    OpenAISettings.getInstance().loadState(newState)
+    assertThat(OpenAISettings.getCurrentState()).isEqualTo(newState)
+    assertThat(form.apiKey).isEqualTo(expected)
+    form.resetForm()
+    assertThat(form.apiKey).isEqualTo("123")
+
+    // change text in form field only, not store
+    form.apiKeyField.text = "456"
+    assertThat(form.apiKey).isEqualTo("456")
+    assertThat(getPassword(OPENAI_API_KEY)).isEqualTo("123")
+
+    // state is equal, but form is modified (password changed)
+    assertThat(OpenAISettings.getCurrentState()).isEqualTo(form.currentState)
+    assertThat(OpenAISettings.getInstance().isModified(form)).isTrue()
+
+    // apply form stores changed password
+    generalSettingsConfigurable.applyOpenAISettings(form)
+    assertThat(getPassword(OPENAI_API_KEY)).isEqualTo("456")
+  }
+
+  private fun youSettingsApiPassword(password: String?) {
+    assertThat(getCredential(YOU_ACCOUNT_PASSWORD)).isNotEqualTo(password)
+
+    // new form reads from store if email is not blank
+    setCredential(YOU_ACCOUNT_PASSWORD, password)
+    val state = YouSettingsState()
+    state.email = "you@mail.ai"
+    val expected = sanitize(password)
+    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo(expected)
+    val form = YouSettingsForm(state, Disposable { })
+    assertThat(form.password).isEqualTo(expected)
+
+    // reset form from store
+    setCredential(YOU_ACCOUNT_PASSWORD, "123")
+    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("123")
+    val newState = YouSettingsState()
+    newState.email = "you@mail.ai"
+    YouSettings.getInstance().loadState(newState)
+    assertThat(YouSettings.getCurrentState()).isEqualTo(newState)
+    assertThat(form.password).isEqualTo(expected)
+    form.resetForm()
+    assertThat(form.password).isEqualTo("123")
+
+    // change text in form field only, not store
+    form.passwordField.text = "456"
+    assertThat(form.password).isEqualTo("456")
+    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("123")
+
+    // blank email resets form to null (not from store)
+    newState.email = "   "
+    form.resetForm()
+    assertThat(form.password).isNull()
+    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("123")
+
+    // Attention: password changed, but form is not modified!
+    assertThat(YouSettings.getCurrentState()).isEqualTo(form.currentState)
+    assertThat(YouSettings.getInstance().isModified(form)).isFalse()
+
+    // Attention: apply form DOES NOT store changed password!
+    generalSettingsConfigurable.applyYouSettings(form)
+    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("123")
+  }
+}

--- a/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsFormTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsFormTest.kt
@@ -270,23 +270,27 @@ class GeneralSettingsFormTest : BasePlatformTestCase() {
     form.resetForm()
     assertThat(form.password).isEqualTo("123")
 
-    // change text in form field only, not store
-    form.passwordField.text = "456"
-    assertThat(form.password).isEqualTo("456")
-    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("123")
-
-    // blank email resets form to null (not from store)
-    newState.email = "   "
+    // blank email resets form password to null (but still stored in store)
+    YouSettings.getCurrentState().email = "   "
     form.resetForm()
     assertThat(form.password).isNull()
     assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("123")
 
-    // Attention: password changed, but form is not modified!
+    // state is equal, but form is modified (password changed)
     assertThat(YouSettings.getCurrentState()).isEqualTo(form.currentState)
-    assertThat(YouSettings.getInstance().isModified(form)).isFalse()
+    assertThat(YouSettings.getInstance().isModified(form)).isTrue()
 
-    // Attention: apply form DOES NOT store changed password!
+    // apply form stores changed password (deleting it)
     generalSettingsConfigurable.applyYouSettings(form)
-    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("123")
+    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isNull()
+
+    // store new password with blank email possible without reset
+    assertThat(YouSettings.getCurrentState().email).isEqualTo(form.email).isBlank()
+    form.passwordField.text = "456"
+    assertThat(form.password).isEqualTo("456")
+    assertThat(YouSettings.getCurrentState()).isEqualTo(form.currentState)
+    assertThat(YouSettings.getInstance().isModified(form)).isTrue()
+    generalSettingsConfigurable.applyYouSettings(form)
+    assertThat(getPassword(YOU_ACCOUNT_PASSWORD)).isEqualTo("456")
   }
 }


### PR DESCRIPTION
Persist credentials, not only settings state:
* Credentials in form are filled/reset from password store
* Credentials are persisted to store on settings apply/ok (actual fix)
* Streamlined credentials to be null if user entered blank (whitespace)
* Credentials form and persistence is tested

Gotchas:
* YouSettingsForm persists to store directly, I suggest to move that to `GeneralSettingsConfigurable` like all other services do (user clicks Apply/OK)