### PR TITLE
Stream code completion and cancel early on newline

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
@@ -43,14 +43,14 @@ class CodeGPTInlineCompletionProvider : InlineCompletionProvider {
             currentCall.set(
                 CompletionRequestService.getInstance().getCodeCompletionAsync(
                     infillRequest,
-                    CodeCompletionEventListener(infillRequest) { suggestion, needCancel ->
-                        if (needCancel) {
+                    CodeCompletionEventListener(infillRequest) { message, cancel ->
+                        if (cancel) {
                             cancelCurrentCall()
                         }
-                        request.editor.putUserData(CodeGPTKeys.PREVIOUS_INLAY_TEXT, suggestion)
+                        request.editor.putUserData(CodeGPTKeys.PREVIOUS_INLAY_TEXT, message)
                         launch {
                             try {
-                                trySend(InlineCompletionGrayTextElement(suggestion))
+                                trySend(InlineCompletionGrayTextElement(message))
                             } catch (e: Exception) {
                                 LOG.error("Failed to send inline completion suggestion", e)
                             }

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
@@ -78,30 +78,12 @@ class CodeGPTInlineCompletionProvider : InlineCompletionProvider {
         private val completed: (String) -> Unit
     ) : CompletionEventListener<String> {
 
-        private var isStreaming = false
-
         override fun onMessage(message: String?, eventSource: EventSource?) {
             if (message != null) {
-                isStreaming = true
                 completed(message.takeWhile { it != '\n' })
                 if (message.contains('\n') && eventSource != null) {
                     eventSource.cancel()
                 }
-            }
-        }
-
-        override fun onComplete(messageBuilder: StringBuilder) {
-            // TODO: https://youtrack.jetbrains.com/issue/CPP-38312/CLion-crashes-around-every-10-minutes-of-work
-            /*val processedOutput = CodeCompletionParserFactory
-                .getParserForFileExtension(requestDetails.fileExtension)
-                .parse(
-                    requestDetails.prefix,
-                    requestDetails.suffix,
-                    messageBuilder.toString()
-                )*/
-            if (!isStreaming) {
-                val output = messageBuilder.toString().takeWhile { it != '\n' }
-                completed(output)
             }
         }
     }


### PR DESCRIPTION
- Stream completion results character by character to provide a more responsive user experience
- Cancel the completion request early when a newline character is encountered to save token usage costs
These changes improve performance, reduce costs, and enhance the overall user experience. Please review and provide feedback.

The current completion suggestion implementation waits for all results before returning the content before the first newline character. This approach is slow and wastes token usage.
```
            val output =
                if (messageBuilder.contains("\n"))
                    messageBuilder.substring(0, messageBuilder.indexOf("\n"))
                else messageBuilder.toString()
            completed(output)
```

By the way, I am a colleague of wsxqyws and I am taking over his work to implement the streaming completion feature for CodeGPT using the new API. 