### PR TITLE
Avoid switching from Custom to OpenAI when seeing chat.completion

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
@@ -41,8 +41,18 @@ public class GeneralSettings implements PersistentStateComponent<GeneralSettings
   public void sync(Conversation conversation) {
     var clientCode = conversation.getClientCode();
     if ("chat.completion".equals(clientCode)) {
-      state.setSelectedService(ServiceType.OPENAI);
-      OpenAISettings.getCurrentState().setModel(conversation.getModel());
+      switch (state.getSelectedService()) {
+        case CUSTOM_OPENAI:
+          // Empty on purpose; we should not set
+          // the selected service back to OPENAI.
+          break;
+
+        case OPENAI:
+        default:
+          state.setSelectedService(ServiceType.OPENAI);
+          OpenAISettings.getCurrentState().setModel(conversation.getModel());
+          break;
+      }
     }
     if ("anthropic.chat.completion".equals(clientCode)) {
       state.setSelectedService(ServiceType.ANTHROPIC);

--- a/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsTest.kt
@@ -25,6 +25,17 @@ class GeneralSettingsTest : BasePlatformTestCase() {
     assertThat(openAISettings.model).isEqualTo("gpt-4")
   }
 
+  fun testCustomOpenAISettingsSync() {
+    val conversation = Conversation()
+    conversation.clientCode = "chat.completion"
+    val settings = GeneralSettings.getInstance()
+    settings.state.selectedService = ServiceType.CUSTOM_OPENAI
+
+    settings.sync(conversation)
+
+    assertThat(settings.state.selectedService).isEqualTo(ServiceType.CUSTOM_OPENAI)
+  }
+
   fun testAzureSettingsSync() {
     val settings = GeneralSettings.getInstance()
     val conversation = Conversation()


### PR DESCRIPTION
I believe this fixes https://github.com/carlrobertoh/CodeGPT/issues/391

The code previously switched current service to OpenAI whenever it was passed a conversation of type `chat.completion`. These code changes removes this behavior if we're using Custom OpenAI, but will keep the old behavior otherwise.