### PR TITLE
Handle custom.openai.chat.completion in GeneralSettings.sync

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
@@ -51,6 +51,9 @@ public class GeneralSettings implements PersistentStateComponent<GeneralSettings
     if ("azure.chat.completion".equals(clientCode)) {
       state.setSelectedService(ServiceType.AZURE);
     }
+    if ("custom.openai.chat.completion".equals(clientCode)) {
+      state.setSelectedService(ServiceType.CUSTOM_OPENAI);
+    }
     if ("llama.chat.completion".equals(clientCode)) {
       state.setSelectedService(ServiceType.LLAMA_CPP);
       var llamaSettings = LlamaSettings.getCurrentState();

--- a/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/settings/state/GeneralSettingsTest.kt
@@ -25,6 +25,17 @@ class GeneralSettingsTest : BasePlatformTestCase() {
     assertThat(openAISettings.model).isEqualTo("gpt-4")
   }
 
+  fun testCustomOpenAISettingsSync() {
+    val conversation = Conversation()
+    conversation.clientCode = "custom.openai.chat.completion"
+    val settings = GeneralSettings.getInstance()
+    settings.state.selectedService = ServiceType.OPENAI
+
+    settings.sync(conversation)
+
+    assertThat(settings.state.selectedService).isEqualTo(ServiceType.CUSTOM_OPENAI)
+  }
+
   fun testAzureSettingsSync() {
     val settings = GeneralSettings.getInstance()
     val conversation = Conversation()


### PR DESCRIPTION
This is a continuation from comments in #466, we should handle `custom.openai.chat.completion` in GeneralSettings.sync
