### PR TITLE
feat: add input field for llama server build parameters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,6 +148,7 @@ tasks {
   runIde {
     enabled = true
     environment("ENVIRONMENT", "LOCAL")
+    autoReloadPlugins.set(false) // is triggered when building llama server
   }
 
   test {

--- a/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerStartupParams.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/llama/LlamaServerStartupParams.java
@@ -3,5 +3,6 @@ package ee.carlrobert.codegpt.completions.llama;
 import java.util.List;
 
 public record LlamaServerStartupParams(String modelPath, int contextLength, int threads, int port,
-                                       List<String> additionalParameters) {
+                                       List<String> additionalRunParameters,
+                                       List<String> additionalBuildParameters) {
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/llama/LlamaSettingsState.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/llama/LlamaSettingsState.java
@@ -23,6 +23,7 @@ public class LlamaSettingsState {
   private int contextSize = 2048;
   private int threads = 8;
   private String additionalParameters = "";
+  private String additionalBuildParameters = "";
   private int topK = 40;
   private double topP = 0.9;
   private double minP = 0.05;
@@ -138,6 +139,14 @@ public class LlamaSettingsState {
     this.additionalParameters = additionalParameters;
   }
 
+  public String getAdditionalBuildParameters() {
+    return additionalBuildParameters;
+  }
+
+  public void setAdditionalBuildParameters(String additionalBuildParameters) {
+    this.additionalBuildParameters = additionalBuildParameters;
+  }
+
   public int getTopK() {
     return topK;
   }
@@ -220,6 +229,7 @@ public class LlamaSettingsState {
         && Objects.equals(baseHost, that.baseHost)
         && Objects.equals(serverPort, that.serverPort)
         && Objects.equals(additionalParameters, that.additionalParameters)
+        && Objects.equals(additionalBuildParameters, that.additionalBuildParameters)
         && codeCompletionsEnabled == that.codeCompletionsEnabled
         && codeCompletionMaxTokens == that.codeCompletionMaxTokens;
   }
@@ -229,7 +239,7 @@ public class LlamaSettingsState {
     return Objects.hash(runLocalServer, useCustomModel, customLlamaModelPath, huggingFaceModel,
         localModelPromptTemplate, remoteModelPromptTemplate, localModelInfillPromptTemplate,
         remoteModelInfillPromptTemplate, baseHost, serverPort, contextSize, threads,
-        additionalParameters, topK, topP, minP, repeatPenalty, codeCompletionsEnabled,
-        codeCompletionMaxTokens);
+        additionalParameters, additionalBuildParameters, topK, topP, minP, repeatPenalty,
+        codeCompletionsEnabled, codeCompletionMaxTokens);
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/LlamaServerPreferencesForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/LlamaServerPreferencesForm.java
@@ -57,6 +57,7 @@ public class LlamaServerPreferencesForm {
   private final IntegerField maxTokensField;
   private final IntegerField threadsField;
   private final JBTextField additionalParametersField;
+  private final JBTextField additionalBuildParametersField;
   private final ChatPromptTemplatePanel remotePromptTemplatePanel;
   private final InfillPromptTemplatePanel infillPromptTemplatePanel;
 
@@ -78,6 +79,9 @@ public class LlamaServerPreferencesForm {
 
     additionalParametersField = new JBTextField(settings.getAdditionalParameters(), 30);
     additionalParametersField.setEnabled(!serverRunning);
+
+    additionalBuildParametersField = new JBTextField(settings.getAdditionalBuildParameters(), 30);
+    additionalBuildParametersField.setEnabled(!serverRunning);
 
     baseHostField = new JBTextField(settings.getBaseHost(), 30);
     apiKeyField = new JBPasswordField();
@@ -124,6 +128,7 @@ public class LlamaServerPreferencesForm {
     maxTokensField.setValue(state.getContextSize());
     threadsField.setValue(state.getThreads());
     additionalParametersField.setText(state.getAdditionalParameters());
+    additionalBuildParametersField.setText(state.getAdditionalBuildParameters());
     remotePromptTemplatePanel.setPromptTemplate(state.getRemoteModelPromptTemplate()); // ?
     infillPromptTemplatePanel.setPromptTemplate(state.getRemoteModelInfillPromptTemplate());
     apiKeyField.setText(CredentialsStore.INSTANCE.getCredential(LLAMA_API_KEY));
@@ -184,9 +189,17 @@ public class LlamaServerPreferencesForm {
                 createComment("settingsConfigurable.service.llama.threads.comment"))
             .addLabeledComponent(
                 CodeGPTBundle.get("settingsConfigurable.service.llama.additionalParameters.label"),
-                additionalParametersField)
-            .addComponentToRightColumn(
-                createComment("settingsConfigurable.service.llama.additionalParameters.comment"))
+                    additionalParametersField)
+                .addComponentToRightColumn(
+                        createComment(
+                            "settingsConfigurable.service.llama.additionalParameters.comment"))
+                .addLabeledComponent(
+                    CodeGPTBundle.get(
+                        "settingsConfigurable.service.llama.additionalBuildParameters.label"),
+                    additionalBuildParametersField)
+                .addComponentToRightColumn(
+                    createComment(
+                        "settingsConfigurable.service.llama.additionalBuildParameters.comment"))
             .addVerticalGap(4)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel()))
@@ -196,6 +209,7 @@ public class LlamaServerPreferencesForm {
   private JButton getServerButton(
       LlamaServerAgent llamaServerAgent,
       ServerProgressPanel serverProgressPanel) {
+    llamaServerAgent.setActiveServerProgressPanel(serverProgressPanel);
     var serverRunning = llamaServerAgent.isServerRunning();
     var serverButton = new JButton();
     serverButton.setText(serverRunning
@@ -218,7 +232,9 @@ public class LlamaServerPreferencesForm {
                 getContextSize(),
                 getThreads(),
                 getServerPort(),
-                getListOfAdditionalParameters()),
+                getListOfAdditionalParameters(),
+                getListOfAdditionalBuildParameters()
+            ),
             serverProgressPanel,
             () -> {
               setFormEnabled(false);
@@ -227,12 +243,12 @@ public class LlamaServerPreferencesForm {
                   Actions.Checked,
                   SwingConstants.LEADING));
             },
-            () -> {
+            (activeServerProgressPanel) -> {
               setFormEnabled(true);
               serverButton.setText(
                   CodeGPTBundle.get("settingsConfigurable.service.llama.startServer.label"));
               serverButton.setIcon(Actions.Execute);
-              serverProgressPanel.displayComponent(new JBLabel(
+              activeServerProgressPanel.displayComponent(new JBLabel(
                   CodeGPTBundle.get("settingsConfigurable.service.llama.progress.serverTerminated"),
                   Actions.Cancel,
                   SwingConstants.LEADING));
@@ -282,7 +298,7 @@ public class LlamaServerPreferencesForm {
     serverButton.setText(
         CodeGPTBundle.get("settingsConfigurable.service.llama.startServer.label"));
     serverButton.setIcon(Actions.Execute);
-    progressPanel.updateText(
+    progressPanel.displayText(
         CodeGPTBundle.get("settingsConfigurable.service.llama.progress.stoppingServer"));
   }
 
@@ -291,7 +307,7 @@ public class LlamaServerPreferencesForm {
     serverButton.setText(
         CodeGPTBundle.get("settingsConfigurable.service.llama.stopServer.label"));
     serverButton.setIcon(Actions.Suspend);
-    progressPanel.startProgress(
+    progressPanel.displayText(
         CodeGPTBundle.get("settingsConfigurable.service.llama.progress.startingServer"));
   }
 
@@ -301,6 +317,7 @@ public class LlamaServerPreferencesForm {
     maxTokensField.setEnabled(enabled);
     threadsField.setEnabled(enabled);
     additionalParametersField.setEnabled(enabled);
+    additionalBuildParametersField.setEnabled(enabled);
   }
 
   public boolean isRunLocalServer() {
@@ -337,9 +354,20 @@ public class LlamaServerPreferencesForm {
 
   public List<String> getListOfAdditionalParameters() {
     return Arrays.stream(additionalParametersField.getText().split(","))
-      .map(String::trim)
-      .filter(s -> !s.isBlank())
-      .toList();
+            .map(String::trim)
+            .filter(s -> !s.isBlank())
+            .toList();
+  }
+
+  public String getAdditionalBuildParameters() {
+    return additionalBuildParametersField.getText();
+  }
+
+  public List<String> getListOfAdditionalBuildParameters() {
+    return Arrays.stream(additionalBuildParametersField.getText().split(","))
+            .map(String::trim)
+            .filter(s -> !s.isBlank())
+            .toList();
   }
 
   public PromptTemplate getPromptTemplate() {

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/LlamaSettingsForm.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/LlamaSettingsForm.java
@@ -41,6 +41,7 @@ public class LlamaSettingsForm extends JPanel {
     state.setContextSize(llamaServerPreferencesForm.getContextSize());
     state.setThreads(llamaServerPreferencesForm.getThreads());
     state.setAdditionalParameters(llamaServerPreferencesForm.getAdditionalParameters());
+    state.setAdditionalBuildParameters(llamaServerPreferencesForm.getAdditionalBuildParameters());
 
     var modelPreferencesForm = llamaServerPreferencesForm.getLlamaModelPreferencesForm();
     state.setCustomLlamaModelPath(modelPreferencesForm.getCustomLlamaModelPath());

--- a/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/ServerProgressPanel.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/llama/form/ServerProgressPanel.java
@@ -8,20 +8,15 @@ import javax.swing.JPanel;
 public class ServerProgressPanel extends JPanel {
 
   private final JBLabel label = new JBLabel();
+  private final AsyncProcessIcon loadingSpinner = new AsyncProcessIcon("sign_in_spinner");
 
-  public ServerProgressPanel() {
-    setVisible(false);
-    add(new AsyncProcessIcon("sign_in_spinner"));
-    add(label);
-  }
-
-  public void startProgress(String text) {
-    setVisible(true);
-    updateText(text);
-  }
-
-  public void updateText(String text) {
+  public void displayText(String text) {
     label.setText(text);
+    removeAll();
+    add(loadingSpinner);
+    add(label);
+    revalidate();
+    repaint();
   }
 
   public void displayComponent(JComponent component) {

--- a/src/main/java/ee/carlrobert/codegpt/ui/OverlayUtil.java
+++ b/src/main/java/ee/carlrobert/codegpt/ui/OverlayUtil.java
@@ -149,4 +149,13 @@ public class OverlayUtil {
         .createBalloon()
         .show(RelativePoint.getSouthOf(component), Position.below);
   }
+
+  public static void showClosableBalloon(String content, MessageType messageType,
+      JComponent component) {
+    JBPopupFactory.getInstance()
+        .createHtmlTextBalloonBuilder(content, messageType, null)
+        .setCloseButtonEnabled(true)
+        .createBalloon()
+        .show(RelativePoint.getSouthOf(component), Position.below);
+  }
 }

--- a/src/main/resources/messages/codegpt.properties
+++ b/src/main/resources/messages/codegpt.properties
@@ -62,6 +62,8 @@ settingsConfigurable.service.llama.threads.label=Threads:
 settingsConfigurable.service.llama.threads.comment=The number of threads available to execute the model. It is not recommended to specify a number greater than the number of processor cores.
 settingsConfigurable.service.llama.additionalParameters.label=Additional parameters:
 settingsConfigurable.service.llama.additionalParameters.comment=<html>Additional command-line parameters for the server startup process, separated by commas. See the full <a href="https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md">list of options</a>.<p><i>Example: "--n-gpu-layers, 1,  --no-mmap, --mlock"</i></p></html>
+settingsConfigurable.service.llama.additionalBuildParameters.label=Additional build parameters:
+settingsConfigurable.service.llama.additionalBuildParameters.comment=<html>Additional command-line parameters for the server build process, separated by commas. See the full <a href="https://github.com/ggerganov/llama.cpp/tree/master?tab=readme-ov-file#build">list of build options</a>.<p><i>Example: "LLAMA_CUBLAS=1,CUDA_DOCKER_ARCH=all"</i></p></html>
 settingsConfigurable.service.llama.baseHost.label=Base host:
 settingsConfigurable.service.llama.baseHost.comment=URL to existing LLama server
 settingsConfigurable.service.llama.startServer.label=Start server
@@ -178,7 +180,7 @@ validation.error.mustBeGreaterThanZero=Value must be greater than 0
 checkForUpdatesTask.title=Checking for CodeGPT update...
 checkForUpdatesTask.notification.message=An update for CodeGPT is available.
 checkForUpdatesTask.notification.installButton=Install update
-llamaServerAgent.buildingProject.description=Building llama.cpp...
+llamaServerAgent.buildingProject.description=Building server...
 llamaServerAgent.serverBootup.description=Booting up server...
 notification.compilationError.description=CodeGPT has detected a compilation error. Would you like assistance in resolving it?
 notification.compilationError.okLabel=Resolve errors


### PR DESCRIPTION
This PR closes #405 

- Adds new input field for Llama-CPP Server build parameters to e.g. enable using GPU via CUDA or similar:
![image](https://github.com/carlrobertoh/CodeGPT/assets/39240633/80b83375-0d2f-41c4-8bd8-25e7b109d8d5)
- Improved error handling when building or running server fails:
![image](https://github.com/carlrobertoh/CodeGPT/assets/39240633/ff9fc082-9b92-469b-836d-31a5415a66ad)
