### PR TITLE
fix: Unsupported code completions

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/service/llama/LlamaSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/service/llama/LlamaSettings.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import ee.carlrobert.codegpt.completions.llama.LlamaModel;
 import ee.carlrobert.codegpt.credentials.CredentialsStore;
 import ee.carlrobert.codegpt.settings.service.llama.form.LlamaSettingsForm;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +30,15 @@ public class LlamaSettings implements PersistentStateComponent<LlamaSettingsStat
 
   public static LlamaSettingsState getCurrentState() {
     return getInstance().getState();
+  }
+
+  /**
+   * Code Completions enabled in settings and a model with InfillPromptTemplate selected.
+   */
+  public static boolean isCodeCompletionsPossible() {
+    return getInstance().getState().isCodeCompletionsEnabled()
+            && LlamaModel.findByHuggingFaceModel(getInstance().getState().getHuggingFaceModel())
+                    .getInfillPromptTemplate() != null;
   }
 
   public static LlamaSettings getInstance() {

--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
@@ -49,7 +49,7 @@ abstract class CodeCompletionFeatureToggleActions(
         return when (serviceType) {
             OPENAI -> OpenAISettings.getCurrentState().isCodeCompletionsEnabled
             CUSTOM_OPENAI -> service<CustomServiceSettings>().state.codeCompletionSettings.codeCompletionsEnabled
-            LLAMA_CPP -> LlamaSettings.getCurrentState().isCodeCompletionsEnabled
+            LLAMA_CPP -> LlamaSettings.isCodeCompletionsPossible()
             else -> false
         }
     }


### PR DESCRIPTION
Most Llama models don't support code completions (only Code Llama and Deepseek Coder).
This PR fixes the NPE that was produced and adds support for Llama 3.

I guess #495 beginning of empty line is not possible with com.intellij.codeInsight.inline.completion.elements.InlineCompletionGrayTextElement.Presentable#render returning on empty text.
But entering tabulators shows no completion either.
Any number of spaces shows completions.
But when followed by a backspace (some spaces deleted), completions disappear again 😅