### PR TITLE
fix: use /infill for llama.cpp code-completions

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
@@ -122,7 +122,7 @@ public final class CompletionRequestService {
           CodeCompletionRequestFactory.buildCustomRequest(requestDetails),
           new OpenAITextCompletionEventSourceListener(eventListener));
       case LLAMA_CPP -> CompletionClientProvider.getLlamaClient()
-          .getChatCompletionAsync(
+          .getInfillAsync(
               CodeCompletionRequestFactory.buildLlamaRequest(requestDetails),
               eventListener);
       default ->

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
@@ -12,6 +12,7 @@ import ee.carlrobert.codegpt.settings.service.llama.LlamaSettings
 import ee.carlrobert.codegpt.settings.service.llama.LlamaSettingsState
 import ee.carlrobert.codegpt.settings.service.openai.OpenAISettings
 import ee.carlrobert.llm.client.llama.completion.LlamaCompletionRequest
+import ee.carlrobert.llm.client.llama.completion.LlamaInfillRequest
 import ee.carlrobert.llm.client.openai.completion.request.OpenAITextCompletionRequest
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
@@ -59,16 +60,14 @@ object CodeCompletionRequestFactory {
     }
 
     @JvmStatic
-    fun buildLlamaRequest(details: InfillRequestDetails): LlamaCompletionRequest {
+    fun buildLlamaRequest(details: InfillRequestDetails): LlamaInfillRequest {
         val settings = LlamaSettings.getCurrentState()
         val promptTemplate = getLlamaInfillPromptTemplate(settings)
-        val prompt = promptTemplate.buildPrompt(details.prefix, details.suffix)
-        return LlamaCompletionRequest.Builder(prompt)
+        return LlamaInfillRequest(LlamaCompletionRequest.Builder(null)
             .setN_predict(settings.codeCompletionMaxTokens)
             .setStream(true)
             .setTemperature(0.4)
-            .setStop(promptTemplate.stopTokens)
-            .build()
+            .setStop(promptTemplate.stopTokens), details.prefix, details.suffix)
     }
 
     private fun getLlamaInfillPromptTemplate(settings: LlamaSettingsState): InfillPromptTemplate {

--- a/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionServiceTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionServiceTest.kt
@@ -35,11 +35,11 @@ class CodeCompletionServiceTest : IntegrationTest() {
          ${"z".repeat(247)}
          """.trimIndent() // 128 tokens
     expectLlama(StreamHttpExchange { request: RequestEntity ->
-      assertThat(request.uri.path).isEqualTo("/completion")
+      assertThat(request.uri.path).isEqualTo("/infill")
       assertThat(request.method).isEqualTo("POST")
       assertThat(request.body)
-        .extracting("prompt")
-        .isEqualTo(InfillPromptTemplate.LLAMA.buildPrompt(prefix, suffix))
+        .extracting("input_prefix", "input_suffix")
+        .containsExactly(prefix, suffix)
       listOf(jsonMapResponse(e("content", expectedCompletion), e("stop", true)))
     })
 


### PR DESCRIPTION
Use `/infill` for Llama.CPP code-completions instead of `/chat/completions` as suggested in https://github.com/carlrobertoh/CodeGPT/pull/510#issuecomment-2077027810