### PR TITLE
fix: focus on new editor action and refresh editor actions on apply

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationComponent.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationComponent.java
@@ -28,7 +28,6 @@ import ee.carlrobert.codegpt.ui.UIUtil;
 import java.awt.Dimension;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
@@ -191,7 +190,12 @@ public class ConfigurationComponent {
   private JPanel createTablePanel() {
     return ToolbarDecorator.createDecorator(table)
         .setPreferredSize(new Dimension(table.getPreferredSize().width, 140))
-        .setAddAction(anActionButton -> getModel().addRow(new Object[]{"", ""}))
+        .setAddAction(anActionButton -> {
+          getModel().addRow(new Object[]{"", ""});
+          int lastRowIndex = getModel().getRowCount() - 1;
+          table.changeSelection(lastRowIndex, 0, false, false);
+          table.editCellAt(lastRowIndex, 0);
+        })
         .setRemoveAction(anActionButton -> getModel().removeRow(table.getSelectedRow()))
         .disableUpAction()
         .disableDownAction()

--- a/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationConfigurable.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/configuration/ConfigurationConfigurable.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.util.Disposer;
 import ee.carlrobert.codegpt.CodeGPTBundle;
+import ee.carlrobert.codegpt.actions.editor.EditorActionsUtil;
 import javax.swing.JComponent;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +40,7 @@ public class ConfigurationConfigurable implements Configurable {
   @Override
   public void apply() {
     ConfigurationSettings.getInstance().loadState(component.getCurrentFormState());
+    EditorActionsUtil.refreshActions();
   }
 
   @Override


### PR DESCRIPTION
This PR fixes #381

- Refreshes Editor Actions after Configuration apply
- Focuses new row when new Editor Action is added (+):
  ![codegpt-add-action-focus](https://github.com/carlrobertoh/CodeGPT/assets/39240633/f0ba19ae-c366-4ca6-9bd7-d088b333c072)
