### PR TITLE
Expand and explicitly handle cases where a ServiceType is checked

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
@@ -1,7 +1,5 @@
 package ee.carlrobert.codegpt.completions;
 
-import static ee.carlrobert.codegpt.settings.service.ServiceType.ANTHROPIC;
-import static ee.carlrobert.codegpt.settings.service.ServiceType.AZURE;
 import static ee.carlrobert.codegpt.settings.service.ServiceType.CUSTOM_OPENAI;
 import static ee.carlrobert.codegpt.settings.service.ServiceType.LLAMA_CPP;
 import static ee.carlrobert.codegpt.settings.service.ServiceType.OPENAI;
@@ -226,19 +224,15 @@ public final class CompletionRequestService {
   }
 
   public static boolean isRequestAllowed(ServiceType serviceType) {
-    if (serviceType == OPENAI
-        && CredentialsStore.INSTANCE.isCredentialSet(CredentialKey.OPENAI_API_KEY)) {
-      return true;
-    }
-
-    var azureCredentialKey = AzureSettings.getCurrentState().isUseAzureApiKeyAuthentication()
-        ? CredentialKey.AZURE_OPENAI_API_KEY
-        : CredentialKey.AZURE_ACTIVE_DIRECTORY_TOKEN;
-    if (serviceType == AZURE && CredentialsStore.INSTANCE.isCredentialSet(azureCredentialKey)) {
-      return true;
-    }
-
-    return List.of(LLAMA_CPP, ANTHROPIC, CUSTOM_OPENAI).contains(serviceType);
+    return switch (serviceType) {
+      case OPENAI -> CredentialsStore.INSTANCE.isCredentialSet(CredentialKey.OPENAI_API_KEY);
+      case AZURE -> CredentialsStore.INSTANCE.isCredentialSet(
+          AzureSettings.getCurrentState().isUseAzureApiKeyAuthentication()
+            ? CredentialKey.AZURE_OPENAI_API_KEY
+            : CredentialKey.AZURE_ACTIVE_DIRECTORY_TOKEN);
+      case CUSTOM_OPENAI, ANTHROPIC, LLAMA_CPP -> true;
+      case YOU -> false;
+    };
   }
 
   /**

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
@@ -70,7 +70,10 @@ class CodeGPTInlineCompletionProvider : InlineCompletionProvider {
             ServiceType.OPENAI -> OpenAISettings.getCurrentState().isCodeCompletionsEnabled
             ServiceType.CUSTOM_OPENAI -> service<CustomServiceSettings>().state.codeCompletionSettings.codeCompletionsEnabled
             ServiceType.LLAMA_CPP -> LlamaSettings.getCurrentState().isCodeCompletionsEnabled
-            else -> false
+            ServiceType.ANTHROPIC,
+            ServiceType.AZURE,
+            ServiceType.YOU,
+            null -> false
         }
         return event is InlineCompletionEvent.DocumentChange && codeCompletionsEnabled
     }


### PR DESCRIPTION
This streamlines changes to ServiceType, where any additions will be flagged at compile time to be handled, instead of silently falling back to a default value.