### PR TITLE
fix: add optional Git4Idea dependency to plugin.xml

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends optional="true" config-file="plugin-java.xml">com.intellij.modules.java</depends>
+    <depends optional="true">Git4Idea</depends>
 
     <projectListeners>
         <listener topic="com.intellij.codeInsight.lookup.LookupManagerListener"


### PR DESCRIPTION
This PR fixes #522 and fixes #523

Tested with:
Ubuntu 22.04
Pycharm Community 2023.3.5

Without the fix:
https://github.com/carlrobertoh/CodeGPT/blob/6d6e0a3ccb739ff9a08a35ce06a7d342cf2510a4/src/main/kotlin/ee/carlrobert/codegpt/settings/configuration/Placeholder.kt#L29
Throws when trying to generate a commit message:
```java
Caused by: java.lang.ClassNotFoundException: git4idea.GitUtil PluginClassLoader(plugin=PluginDescriptor(name=CodeGPT, id=ee.carlrobert.chatgpt, descriptorPath=plugin.xml, path=~/IdeaProjects/git/CodeGPT/build/idea-sandbox/plugins/CodeGPT, version=2.6.3-233, package=null, isBundled=false), packagePrefix=null, state=active)
```