### PR TITLE
fix: CustomService Test connection with correct settings

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceChatCompletionForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceChatCompletionForm.kt
@@ -15,7 +15,10 @@ import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 
-class CustomServiceChatCompletionForm(state: CustomServiceChatCompletionSettingsState) {
+class CustomServiceChatCompletionForm(
+    state: CustomServiceChatCompletionSettingsState,
+    val getApiKey: () -> String?
+) {
 
     private val urlField = JBTextField(state.url, 30)
     private val tabbedPane = CustomServiceFormTabbedPane(state.headers, state.body)
@@ -67,7 +70,13 @@ class CustomServiceChatCompletionForm(state: CustomServiceChatCompletionSettings
 
     private fun testConnection() {
         CompletionRequestService.getInstance().getCustomOpenAIChatCompletionAsync(
-            CompletionRequestProvider.buildCustomOpenAICompletionRequest("Hello!"),
+            CompletionRequestProvider.buildCustomOpenAICompletionRequest(
+                "Test",
+                urlField.text,
+                tabbedPane.headers,
+                tabbedPane.body,
+                getApiKey.invoke()
+            ),
             TestConnectionEventListener()
         )
     }

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceCodeCompletionForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceCodeCompletionForm.kt
@@ -28,7 +28,10 @@ import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 
-class CustomServiceCodeCompletionForm(state: CustomServiceCodeCompletionSettingsState) {
+class CustomServiceCodeCompletionForm(
+    state: CustomServiceCodeCompletionSettingsState,
+    val getApiKey: () -> String?
+) {
 
     private val featureEnabledCheckBox = JBCheckBox(
         CodeGPTBundle.get("codeCompletionsForm.enableFeatureText"),
@@ -138,7 +141,14 @@ class CustomServiceCodeCompletionForm(state: CustomServiceCodeCompletionSettings
 
     private fun testConnection() {
         CompletionRequestService.getInstance().getCustomOpenAICompletionAsync(
-            CodeCompletionRequestFactory.buildCustomRequest(InfillRequestDetails("Hello", "!")),
+            CodeCompletionRequestFactory.buildCustomRequest(
+                InfillRequestDetails("Hello", "!"),
+                urlField.text,
+                tabbedPane.headers,
+                tabbedPane.body,
+                promptTemplateComboBox.selectedItem as InfillPromptTemplate,
+                getApiKey.invoke()
+            ),
             TestConnectionEventListener()
         )
     }

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceForm.kt
@@ -34,8 +34,8 @@ class CustomServiceForm {
 
     init {
         val state = service<CustomServiceSettings>().state
-        chatCompletionsForm = CustomServiceChatCompletionForm(state.chatCompletionSettings)
-        codeCompletionsForm = CustomServiceCodeCompletionForm(state.codeCompletionSettings)
+        chatCompletionsForm = CustomServiceChatCompletionForm(state.chatCompletionSettings, this::getApiKey)
+        codeCompletionsForm = CustomServiceCodeCompletionForm(state.codeCompletionSettings, this::getApiKey)
         tabbedPane = JTabbedPane().apply {
             add(CodeGPTBundle.get("shared.chatCompletions"), chatCompletionsForm.form)
             add(CodeGPTBundle.get("shared.codeCompletions"), codeCompletionsForm.form)


### PR DESCRIPTION
This PR fixes #528 
The `Test Connection` in the `CustomServiceForm` was using the currently saved settings instead of the settings from the currently open UI, therefore leading to confusing Error messages, if you e.g. switch from Azure to Ollama and then clicking `Test Connection` without hitting `Apply` before.