### PR TITLE
feat: add Mistral AI service template

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceChatCompletionTemplate.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceChatCompletionTemplate.kt
@@ -89,6 +89,16 @@ enum class CustomServiceChatCompletionTemplate(
         "http://localhost:8080/v1/chat/completions",
         getDefaultHeaders(),
         getDefaultBodyParams(emptyMap())
+    ),
+    MISTRAL_AI(
+        "https://api.mistral.ai/v1/chat/completions",
+        getDefaultHeaders("Authorization", "Bearer \$CUSTOM_SERVICE_API_KEY"),
+        getDefaultBodyParams(
+            mapOf(
+                "model" to "open-mistral-7b",
+                "max_tokens" to 1024
+            )
+        )
     );
 }
 

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceTemplate.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/CustomServiceTemplate.kt
@@ -61,6 +61,11 @@ enum class CustomServiceTemplate(
         "LLaMA C/C++",
         "https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md",
         CustomServiceChatCompletionTemplate.LLAMA_CPP
+    ),
+    MISTRAL_AI(
+        "Mistral AI",
+        "https://docs.mistral.ai/getting-started/quickstart",
+        CustomServiceChatCompletionTemplate.MISTRAL_AI
     );
 
     override fun toString(): String {


### PR DESCRIPTION
This PR closes #403 
Adds `CustomServiceTemplate` for [Mistral AI API](https://docs.mistral.ai/getting-started/quickstart/)