### PR TITLE
Revert "fix: use /infill for llama.cpp code-completions (#513)"

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
@@ -120,7 +120,7 @@ public final class CompletionRequestService {
           CodeCompletionRequestFactory.buildCustomRequest(requestDetails),
           new OpenAITextCompletionEventSourceListener(eventListener));
       case LLAMA_CPP -> CompletionClientProvider.getLlamaClient()
-          .getInfillAsync(
+          .getChatCompletionAsync(
               CodeCompletionRequestFactory.buildLlamaRequest(requestDetails),
               eventListener);
       default ->

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionRequestFactory.kt
@@ -12,7 +12,6 @@ import ee.carlrobert.codegpt.settings.service.llama.LlamaSettings
 import ee.carlrobert.codegpt.settings.service.llama.LlamaSettingsState
 import ee.carlrobert.codegpt.settings.service.openai.OpenAISettings
 import ee.carlrobert.llm.client.llama.completion.LlamaCompletionRequest
-import ee.carlrobert.llm.client.llama.completion.LlamaInfillRequest
 import ee.carlrobert.llm.client.openai.completion.request.OpenAITextCompletionRequest
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
@@ -60,14 +59,16 @@ object CodeCompletionRequestFactory {
     }
 
     @JvmStatic
-    fun buildLlamaRequest(details: InfillRequestDetails): LlamaInfillRequest {
+    fun buildLlamaRequest(details: InfillRequestDetails): LlamaCompletionRequest {
         val settings = LlamaSettings.getCurrentState()
         val promptTemplate = getLlamaInfillPromptTemplate(settings)
-        return LlamaInfillRequest(LlamaCompletionRequest.Builder(null)
+        val prompt = promptTemplate.buildPrompt(details.prefix, details.suffix)
+        return LlamaCompletionRequest.Builder(prompt)
             .setN_predict(settings.codeCompletionMaxTokens)
             .setStream(true)
             .setTemperature(0.4)
-            .setStop(promptTemplate.stopTokens), details.prefix, details.suffix)
+            .setStop(promptTemplate.stopTokens)
+            .build()
     }
 
     private fun getLlamaInfillPromptTemplate(settings: LlamaSettingsState): InfillPromptTemplate {

--- a/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionServiceTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionServiceTest.kt
@@ -35,11 +35,11 @@ class CodeCompletionServiceTest : IntegrationTest() {
          ${"z".repeat(247)}
          """.trimIndent() // 128 tokens
     expectLlama(StreamHttpExchange { request: RequestEntity ->
-      assertThat(request.uri.path).isEqualTo("/infill")
+      assertThat(request.uri.path).isEqualTo("/completion")
       assertThat(request.method).isEqualTo("POST")
       assertThat(request.body)
-        .extracting("input_prefix", "input_suffix")
-        .containsExactly(prefix, suffix)
+        .extracting("prompt")
+        .isEqualTo(InfillPromptTemplate.LLAMA.buildPrompt(prefix, suffix))
       listOf(jsonMapResponse(e("content", expectedCompletion), e("stop", true)))
     })
 


### PR DESCRIPTION
This reverts commit 8de72b330178fa97b0482e1dbb2829964f8b737a.

As discussed in [#510 ](https://github.com/carlrobertoh/CodeGPT/pull/510#issuecomment-2096486472) this reverts the switch from `/completion` to `/infill`