### PR TITLE
fix: refresh Ollama models only when service is changed to Ollama

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsComponent.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettingsComponent.java
@@ -74,8 +74,13 @@ public class GeneralSettingsComponent {
     serviceComboBox = new ComboBox<>(serviceComboBoxModel);
     serviceComboBox.setSelectedItem(OPENAI);
     serviceComboBox.setPreferredSize(displayNameField.getPreferredSize());
-    serviceComboBox.addItemListener(e ->
-        cardLayout.show(cards, ((ServiceType) e.getItem()).getCode()));
+    serviceComboBox.addItemListener(e -> {
+      ServiceType selectedService = (ServiceType) e.getItem();
+      cardLayout.show(cards, selectedService.getCode());
+      if (selectedService == OLLAMA) {
+        ollamaSettingsForm.refreshModels();
+      }
+    });
     mainPanel = FormBuilder.createFormBuilder()
         .addLabeledComponent(
             CodeGPTBundle.get("settingsConfigurable.displayName.label"),

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettingsForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/ollama/OllamaSettingsForm.kt
@@ -55,7 +55,6 @@ class OllamaSettingsForm {
             }
         }
         refreshModelsButton.addActionListener { refreshModels() }
-        refreshModels()
     }
 
     fun getForm(): JPanel = FormBuilder.createFormBuilder()
@@ -116,16 +115,7 @@ class OllamaSettingsForm {
                 || codeCompletionConfigurationForm.fimTemplate != fimTemplate
     }
 
-    private fun disableModelComboBoxWithPlaceholder(placeholderModel: ComboBoxModel<String>) {
-        invokeLater {
-            modelComboBox.apply {
-                model = placeholderModel
-                isEnabled = false
-            }
-        }
-    }
-
-    private fun refreshModels() {
+    fun refreshModels() {
         disableModelComboBoxWithPlaceholder(DefaultComboBoxModel(arrayOf("Loading")))
         try {
             val models = runBlocking(Dispatchers.IO) {
@@ -158,6 +148,15 @@ class OllamaSettingsForm {
                 OverlayUtil.showNotification(ex.message, NotificationType.ERROR)
             }
             disableModelComboBoxWithPlaceholder(DefaultComboBoxModel(arrayOf("Unable to load models")))
+        }
+    }
+
+    private fun disableModelComboBoxWithPlaceholder(placeholderModel: ComboBoxModel<String>) {
+        invokeLater {
+            modelComboBox.apply {
+                model = placeholderModel
+                isEnabled = false
+            }
         }
     }
 }


### PR DESCRIPTION
The `refreshModels()` was initially called in the constructor of `OllamaSettingsForm`.
Because of this whenever the user opens the settings the GET `/api/tags` request is triggered to refresh the Ollama models, even if Ollama is not even the currently selected service 