### PR TITLE
feat: add keyboard shortcuts for Editor actions

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/editor/ShowEditorActionGroupAction.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/editor/ShowEditorActionGroupAction.kt
@@ -1,0 +1,22 @@
+package ee.carlrobert.codegpt.actions.editor
+
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.JBPopupFactory.ActionSelectionAid
+import com.intellij.ui.awt.RelativePoint
+import ee.carlrobert.codegpt.CodeGPTBundle
+import java.awt.MouseInfo
+
+class ShowEditorActionGroupAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val actionManager = ActionManager.getInstance()
+        val actionGroup = actionManager.getAction("action.editor.group.EditorActionGroup")
+        JBPopupFactory.getInstance().createActionGroupPopup(
+            CodeGPTBundle.get("project.label"), (actionGroup as ActionGroup), e.dataContext,
+            ActionSelectionAid.ALPHA_NUMBERING, true
+        ).show(RelativePoint(MouseInfo.getPointerInfo().location))
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,11 @@
             <add-to-group group-id="EditorPopupMenu1" anchor="first"/>
             <separator/>
         </group>
+        <action id="CodeGPT.TriggerEditorPopup"
+          class="ee.carlrobert.codegpt.actions.editor.ShowEditorActionGroupAction"
+          text="Show CodeGPT Actions">
+            <keyboard-shortcut first-keystroke="ctrl shift alt m" keymap="$default"/>
+        </action>
         <group id="CodeGPT.ProjectViewPopupMenuRootGroup">
             <group id="CodeGPT.ProjectViewPopupMenuGroup"
               text="CodeGPT"


### PR DESCRIPTION
This PR closes #314

Adds Action to show CodeGPT Actions popup with keyboard shortcut:
![popup-shortcuts](https://github.com/carlrobertoh/CodeGPT/assets/39240633/b86c6674-573b-480a-a981-9ef1f95ee1ee)

All Actions are assigned an alpha-numeric letter for seamless keyboard controls.


I didn't really know how to define the best default shortcut, so I sticked with the  `CTRL+SHIFT+ALT` combo plus "M" (maybe "M" for "Menu"?), that doesn't seem to be used by anything too important:
![image](https://github.com/carlrobertoh/CodeGPT/assets/39240633/663c1655-d931-46be-b580-2d1d33bc7b16)

