### PR TITLE
feat: Visualize downloaded models

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/actions/GenerateGitCommitMessageAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/actions/GenerateGitCommitMessageAction.java
@@ -62,14 +62,12 @@ public class GenerateGitCommitMessageAction extends AnAction {
   @Override
   public void update(@NotNull AnActionEvent event) {
     var commitWorkflowUi = event.getData(VcsDataKeys.COMMIT_WORKFLOW_UI);
-    var selectedService = GeneralSettings.getCurrentState().getSelectedService();
-    if (selectedService == YOU || commitWorkflowUi == null) {
+    if (GeneralSettings.isSelected(YOU) || commitWorkflowUi == null) {
       event.getPresentation().setVisible(false);
       return;
     }
 
-    var callAllowed = CompletionRequestService.isRequestAllowed(
-        GeneralSettings.getCurrentState().getSelectedService());
+    var callAllowed = CompletionRequestService.isRequestAllowed();
     event.getPresentation().setEnabled(callAllowed
         && new CommitWorkflowChanges(commitWorkflowUi).isFilesSelected());
     event.getPresentation().setText(CodeGPTBundle.get(callAllowed

--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestProvider.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestProvider.java
@@ -449,8 +449,7 @@ public class CompletionRequestProvider {
       CallParameters callParameters) {
     var messages = buildOpenAIMessages(callParameters);
 
-    if (model == null
-        || GeneralSettings.getCurrentState().getSelectedService() == ServiceType.YOU) {
+    if (model == null || GeneralSettings.isSelected(ServiceType.YOU)) {
       return messages;
     }
 

--- a/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/CompletionRequestService.java
@@ -81,7 +81,7 @@ public final class CompletionRequestService {
       CompletionEventListener<String> eventListener) {
     var application = ApplicationManager.getApplication();
     var requestProvider = new CompletionRequestProvider(callParameters.getConversation());
-    return switch (GeneralSettings.getCurrentState().getSelectedService()) {
+    return switch (GeneralSettings.getSelectedService()) {
       case CODEGPT -> CompletionClientProvider.getCodeGPTClient().getChatCompletionAsync(
           requestProvider.buildOpenAIChatCompletionRequest(
               application.getService(CodeGPTServiceSettings.class)
@@ -141,7 +141,7 @@ public final class CompletionRequestService {
         new OpenAIChatCompletionStandardMessage("system", systemPrompt),
         new OpenAIChatCompletionStandardMessage("user", gitDiff)))
         .setModel(OpenAISettings.getCurrentState().getModel());
-    var selectedService = GeneralSettings.getCurrentState().getSelectedService();
+    var selectedService = GeneralSettings.getSelectedService();
     switch (selectedService) {
       case CODEGPT:
         CompletionClientProvider.getCodeGPTClient().getChatCompletionAsync(
@@ -243,7 +243,7 @@ public final class CompletionRequestService {
 
   public Optional<String> getLookupCompletion(String prompt) {
     var openaiRequest = CompletionRequestProvider.buildOpenAILookupCompletionRequest(prompt);
-    var selectedService = GeneralSettings.getCurrentState().getSelectedService();
+    var selectedService = GeneralSettings.getSelectedService();
     switch (selectedService) {
       case CODEGPT:
         var model = ApplicationManager.getApplication().getService(CodeGPTServiceSettings.class)
@@ -273,8 +273,12 @@ public final class CompletionRequestService {
     }
   }
 
-  public boolean isRequestAllowed() {
-    return isRequestAllowed(GeneralSettings.getCurrentState().getSelectedService());
+  public boolean isAllowed() {
+    return isRequestAllowed();
+  }
+
+  public static boolean isRequestAllowed() {
+    return isRequestAllowed(GeneralSettings.getSelectedService());
   }
 
   public static boolean isRequestAllowed(ServiceType serviceType) {

--- a/src/main/java/ee/carlrobert/codegpt/completions/HuggingFaceModel.java
+++ b/src/main/java/ee/carlrobert/codegpt/completions/HuggingFaceModel.java
@@ -1,9 +1,12 @@
 package ee.carlrobert.codegpt.completions;
 
+import static ee.carlrobert.codegpt.completions.llama.LlamaModel.getDownloadedMarker;
+import static ee.carlrobert.codegpt.completions.llama.LlamaModel.getLlamaModelsPath;
 import static java.lang.String.format;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import org.jetbrains.annotations.NotNull;
 
 public enum HuggingFaceModel {
 
@@ -179,6 +182,14 @@ public enum HuggingFaceModel {
   }
 
   public String getQuantizationLabel() {
-    return format("%d-bit precision", quantization);
+    return format("%s %d-bit precision", downloaded(), quantization);
+  }
+
+  public boolean isDownloaded() {
+    return getLlamaModelsPath().resolve(fileName).toFile().exists();
+  }
+
+  private @NotNull String downloaded() {
+    return getDownloadedMarker(isDownloaded());
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/conversations/ConversationService.java
+++ b/src/main/java/ee/carlrobert/codegpt/conversations/ConversationService.java
@@ -49,8 +49,7 @@ public final class ConversationService {
     conversation.setClientCode(clientCode);
     conversation.setCreatedOn(LocalDateTime.now());
     conversation.setUpdatedOn(LocalDateTime.now());
-    conversation.setModel(getModelForSelectedService(
-        GeneralSettings.getCurrentState().getSelectedService()));
+    conversation.setModel(getModelForSelectedService(GeneralSettings.getSelectedService()));
     return conversation;
   }
 
@@ -113,7 +112,7 @@ public final class ConversationService {
   }
 
   public Conversation startConversation() {
-    var completionCode = GeneralSettings.getCurrentState().getSelectedService().getCompletionCode();
+    var completionCode = GeneralSettings.getSelectedService().getCompletionCode();
     var conversation = createConversation(completionCode);
     conversationState.setCurrentConversation(conversation);
     addConversation(conversation);

--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
@@ -105,7 +105,8 @@ public class GeneralSettings implements PersistentStateComponent<GeneralSettings
         var huggingFaceModel = llamaSettings.getHuggingFaceModel();
         var llamaModel = LlamaModel.findByHuggingFaceModel(huggingFaceModel);
         return String.format(
-            "%s %dB (Q%d)",
+            "%s %s %dB (Q%d)",
+            llamaModel.getDownloadedMarker(),
             llamaModel.getLabel(),
             huggingFaceModel.getParameterSize(),
             huggingFaceModel.getQuantization());

--- a/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
+++ b/src/main/java/ee/carlrobert/codegpt/settings/GeneralSettings.java
@@ -41,6 +41,14 @@ public class GeneralSettings implements PersistentStateComponent<GeneralSettings
     return ApplicationManager.getApplication().getService(GeneralSettings.class);
   }
 
+  public static ServiceType getSelectedService() {
+    return getCurrentState().getSelectedService();
+  }
+
+  public static boolean isSelected(ServiceType serviceType) {
+    return getSelectedService() == serviceType;
+  }
+
   public void sync(Conversation conversation) {
     var clientCode = conversation.getClientCode();
     if ("chat.completion".equals(clientCode)) {

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabPanel.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabPanel.java
@@ -229,7 +229,7 @@ public class ChatToolWindowTabPanel implements Disposable {
   private void call(CallParameters callParameters, ResponsePanel responsePanel) {
     var responseContainer = (ChatMessageResponseBody) responsePanel.getContent();
 
-    if (!CompletionRequestService.getInstance().isRequestAllowed()) {
+    if (!CompletionRequestService.getInstance().isAllowed()) {
       responseContainer.displayMissingCredential();
       return;
     }
@@ -359,7 +359,7 @@ public class ChatToolWindowTabPanel implements Disposable {
     gbc.fill = GridBagConstraints.HORIZONTAL;
     gbc.gridy = 1;
     rootPanel.add(
-        createUserPromptPanel(GeneralSettings.getCurrentState().getSelectedService()), gbc);
+        createUserPromptPanel(GeneralSettings.getSelectedService()), gbc);
     return rootPanel;
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/ChatToolWindowScrollablePanel.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/ChatToolWindowScrollablePanel.java
@@ -28,7 +28,7 @@ public class ChatToolWindowScrollablePanel extends ScrollablePanel {
   public void displayLandingView(JComponent landingView) {
     clearAll();
     add(landingView);
-    if (GeneralSettings.getCurrentState().getSelectedService() == ServiceType.CODEGPT
+    if (GeneralSettings.isSelected(ServiceType.CODEGPT)
         && !CredentialsStore.INSTANCE.isCredentialSet(CredentialKey.CODEGPT_API_KEY)) {
 
       var panel = new ResponsePanel()

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/ModelComboBoxAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/ModelComboBoxAction.java
@@ -159,7 +159,7 @@ public class ModelComboBoxAction extends ComboBoxAction {
           if (!YouUserManager.getInstance().isSubscribed()
               && youSettings.getChatMode() != YouCompletionMode.DEFAULT) {
             youSettings.setChatMode(YouCompletionMode.DEFAULT);
-            updateTemplatePresentation(GeneralSettings.getCurrentState().getSelectedService());
+            updateTemplatePresentation(GeneralSettings.getSelectedService());
           }
         }
     );

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/ModelComboBoxAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/ModelComboBoxAction.java
@@ -240,9 +240,11 @@ public class ModelComboBoxAction extends ComboBoxAction {
 
   private String getSelectedHuggingFace() {
     var huggingFaceModel = LlamaSettings.getCurrentState().getHuggingFaceModel();
+    var llamaModel = LlamaModel.findByHuggingFaceModel(huggingFaceModel);
     return format(
-        "%s %dB (Q%d)",
-        LlamaModel.findByHuggingFaceModel(huggingFaceModel).getLabel(),
+        "%s %s %dB (Q%d)",
+        llamaModel.getDownloadedMarker(),
+        llamaModel.getLabel(),
         huggingFaceModel.getParameterSize(),
         huggingFaceModel.getQuantization());
   }

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/TotalTokensPanel.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/TotalTokensPanel.java
@@ -163,7 +163,7 @@ public class TotalTokensPanel extends JPanel {
   }
 
   private String getIconToolTipText(String html) {
-    if (GeneralSettings.getCurrentState().getSelectedService() != ServiceType.OPENAI) {
+    if (!GeneralSettings.isSelected(ServiceType.OPENAI)) {
       return """
           <html
           <p style="margin: 4px 0;">

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/UserPromptTextArea.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ui/textarea/UserPromptTextArea.java
@@ -191,7 +191,7 @@ public class UserPromptTextArea extends JPanel {
             handleSubmit();
           }
         }));
-    var selectedService = GeneralSettings.getCurrentState().getSelectedService();
+    var selectedService = GeneralSettings.getSelectedService();
     if (selectedService == ANTHROPIC
         || selectedService == OLLAMA
         || (selectedService == OPENAI

--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
@@ -17,7 +17,7 @@ abstract class CodeCompletionFeatureToggleActions(
     private val enableFeatureAction: Boolean
 ) : DumbAwareAction() {
 
-    override fun actionPerformed(e: AnActionEvent) = when (GeneralSettings.getCurrentState().selectedService) {
+    override fun actionPerformed(e: AnActionEvent) = when (GeneralSettings.getSelectedService()) {
         CODEGPT -> service<CodeGPTServiceSettings>().state.codeCompletionSettings::codeCompletionsEnabled::set
 
         OPENAI -> OpenAISettings.getCurrentState()::setCodeCompletionsEnabled
@@ -36,7 +36,7 @@ abstract class CodeCompletionFeatureToggleActions(
     }(enableFeatureAction)
 
     override fun update(e: AnActionEvent) {
-        val selectedService = GeneralSettings.getCurrentState().selectedService
+        val selectedService = GeneralSettings.getSelectedService()
         val codeCompletionEnabled =
             e.project?.service<CodeCompletionService>()?.isCodeCompletionsEnabled(selectedService) ?: false
         e.presentation.isVisible = codeCompletionEnabled != enableFeatureAction

--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/CodeCompletionFeatureToggleActions.kt
@@ -17,35 +17,28 @@ abstract class CodeCompletionFeatureToggleActions(
     private val enableFeatureAction: Boolean
 ) : DumbAwareAction() {
 
-    override fun actionPerformed(e: AnActionEvent) {
-        when (GeneralSettings.getCurrentState().selectedService) {
-            CODEGPT ->
-                service<CodeGPTServiceSettings>().state.codeCompletionSettings.codeCompletionsEnabled
+    override fun actionPerformed(e: AnActionEvent) = when (GeneralSettings.getCurrentState().selectedService) {
+        CODEGPT -> service<CodeGPTServiceSettings>().state.codeCompletionSettings::codeCompletionsEnabled::set
 
-            OPENAI ->
-                OpenAISettings.getCurrentState().isCodeCompletionsEnabled = enableFeatureAction
+        OPENAI -> OpenAISettings.getCurrentState()::setCodeCompletionsEnabled
 
-            LLAMA_CPP ->
-                LlamaSettings.getCurrentState().isCodeCompletionsEnabled = enableFeatureAction
+        LLAMA_CPP -> LlamaSettings.getCurrentState()::setCodeCompletionsEnabled
 
-            OLLAMA -> service<OllamaSettings>().state.codeCompletionsEnabled = enableFeatureAction
-            CUSTOM_OPENAI -> service<CustomServiceSettings>().state
-                .codeCompletionSettings
-                .codeCompletionsEnabled = enableFeatureAction
+        OLLAMA -> service<OllamaSettings>().state::codeCompletionsEnabled::set
 
-            ANTHROPIC,
-            AZURE,
-            YOU,
-            GOOGLE,
-            null -> { /* no-op for these services */
-            }
-        }
-    }
+        CUSTOM_OPENAI -> service<CustomServiceSettings>().state.codeCompletionSettings::codeCompletionsEnabled::set
+
+        ANTHROPIC,
+        AZURE,
+        YOU,
+        GOOGLE,
+        null -> { _: Boolean -> Unit } // no-op for these services
+    }(enableFeatureAction)
 
     override fun update(e: AnActionEvent) {
         val selectedService = GeneralSettings.getCurrentState().selectedService
         val codeCompletionEnabled =
-            service<CodeCompletionService>().isCodeCompletionsEnabled(selectedService)
+            e.project?.service<CodeCompletionService>()?.isCodeCompletionsEnabled(selectedService) ?: false
         e.presentation.isVisible = codeCompletionEnabled != enableFeatureAction
         e.presentation.isEnabled = when (selectedService) {
             CODEGPT,

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionService.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeCompletionService.kt
@@ -37,7 +37,7 @@ class CodeCompletionService {
         requestDetails: InfillRequestDetails,
         eventListener: CompletionEventListener<String>
     ): EventSource =
-        when (val selectedService = GeneralSettings.getCurrentState().selectedService) {
+        when (val selectedService = GeneralSettings.getSelectedService()) {
             CODEGPT -> CompletionClientProvider.getCodeGPTClient()
                 .getCompletionAsync(buildCodeGPTRequest(requestDetails), eventListener)
 

--- a/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/codecompletions/CodeGPTInlineCompletionProvider.kt
@@ -67,7 +67,7 @@ class CodeGPTInlineCompletionProvider : InlineCompletionProvider {
     }
 
     override fun isEnabled(event: InlineCompletionEvent): Boolean {
-        val selectedService = GeneralSettings.getCurrentState().selectedService
+        val selectedService = GeneralSettings.getSelectedService()
         val codeCompletionsEnabled = when (selectedService) {
             ServiceType.CODEGPT -> service<CodeGPTServiceSettings>().state.codeCompletionSettings.codeCompletionsEnabled
             ServiceType.OPENAI -> OpenAISettings.getCurrentState().isCodeCompletionsEnabled


### PR DESCRIPTION
With more and more LLaMA models users should have a clear path to select/switch one of their downloaded models in as few clicks as possible.
<img width="497" alt="Select Quantization" src="https://github.com/carlrobertoh/CodeGPT/assets/65483435/a4767eae-25d2-4095-a541-0fceeb9ff4d6">
<img width="497" alt="Select Model" src="https://github.com/carlrobertoh/CodeGPT/assets/65483435/2aff4123-a9e4-4ea1-bd6e-35c4705c5bbe">
