### PR TITLE
feat: add OpenRouter service template

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/template/CustomServiceChatCompletionTemplate.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/template/CustomServiceChatCompletionTemplate.kt
@@ -99,6 +99,22 @@ enum class CustomServiceChatCompletionTemplate(
                 "max_tokens" to 1024
             )
         )
+    ),
+    OPEN_ROUTER(
+        "https://openrouter.ai/api/v1/chat/completions",
+        getDefaultHeaders(
+            mapOf(
+                "Authorization" to "Bearer \$CUSTOM_SERVICE_API_KEY",
+                "HTTP-Referer" to "https://plugins.jetbrains.com/plugin/21056-codegpt",
+                "X-Title" to "CodeGPT"
+            )
+        ),
+        getDefaultBodyParams(
+            mapOf(
+                "model" to "meta-llama/llama-3-8b-instruct:free",
+                "max_tokens" to 1024
+            )
+        )
     );
 }
 

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/template/CustomServiceTemplate.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/template/CustomServiceTemplate.kt
@@ -66,6 +66,11 @@ enum class CustomServiceTemplate(
         "Mistral AI",
         "https://docs.mistral.ai/getting-started/quickstart",
         CustomServiceChatCompletionTemplate.MISTRAL_AI
+    ),
+    OPEN_ROUTER(
+        "OpenRouter",
+        "https://openrouter.ai/docs#quick-start",
+        CustomServiceChatCompletionTemplate.OPEN_ROUTER
     );
 
     override fun toString(): String {


### PR DESCRIPTION
This PR adds a Custom OpenAI Service template for [OpenRouter](https://openrouter.ai/docs#quick-start)
(Motivation: https://github.com/carlrobertoh/CodeGPT/issues/310#issuecomment-2129951826)