### PR TITLE
Enable vision support in GUI for Azure models #649

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/UserInputPanel.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/UserInputPanel.kt
@@ -150,6 +150,7 @@ class UserInputPanel(
         return when (service<GeneralSettings>().state.selectedService) {
             ServiceType.CUSTOM_OPENAI,
             ServiceType.ANTHROPIC,
+            ServiceType.AZURE,
             ServiceType.OLLAMA -> true
 
             ServiceType.CODEGPT -> {


### PR DESCRIPTION
This enables vision support in the GUI as discussed.

I tested it with a model that supports vision (gpt-4o) as well as with one that does not (gpt-4-32k).

The resulting behaviour is attached in screenshots.

![non-vision-azure-model](https://github.com/user-attachments/assets/900127a7-f037-4344-b57e-ccfc47fa3409)
![vision-azure-model](https://github.com/user-attachments/assets/b6c8f3c5-6214-4e5e-b1df-a4dcd972a72d)
