### PR TITLE
fix: update OpenRouter model version in custom OpenAI provider

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/template/CustomServiceChatCompletionTemplate.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/service/custom/template/CustomServiceChatCompletionTemplate.kt
@@ -111,7 +111,7 @@ enum class CustomServiceChatCompletionTemplate(
         ),
         getDefaultBodyParams(
             mapOf(
-                "model" to "meta-llama/llama-3-8b-instruct:free",
+                "model" to "meta-llama/llama-3.1-8b-instruct:free",
                 "max_tokens" to 1024
             )
         )


### PR DESCRIPTION
- Updated the model version for the OpenRouter configuration in the custom OpenAI provider from `meta-llama/llama-3-8b-instruct:free` to `meta-llama/llama-3.1-8b-instruct:free`