### PR TITLE
fix backtick code overflowing and going out of view

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/ui/UIUtil.java
+++ b/src/main/java/ee/carlrobert/codegpt/ui/UIUtil.java
@@ -44,6 +44,8 @@ import javax.swing.KeyStroke;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.text.DefaultCaret;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
 
 public class UIUtil {
 
@@ -60,7 +62,10 @@ public class UIUtil {
   public static JTextPane createTextPane(String text, boolean opaque, HyperlinkListener listener) {
     var textPane = new JTextPane();
     textPane.putClientProperty(JTextPane.HONOR_DISPLAY_PROPERTIES, true);
-    textPane.setEditorKit(HTMLEditorKitBuilder.simple());
+    var editorKit = new HTMLEditorKitBuilder().withWordWrapViewFactory().build();
+    StyleSheet styleSheet = editorKit.getStyleSheet();
+    styleSheet.addRule("code { white-space: pre-wrap; word-wrap: break-word; }");
+    textPane.setEditorKit(editorKit);
     textPane.addHyperlinkListener(listener);
     textPane.setContentType("text/html");
     textPane.setEditable(false);


### PR DESCRIPTION
Previously when text was enclosed in backticks, that text wouldn't wrap, and would instead overflow beyond the viewport. In addition, there is no horizontal scroll bar, so the text is completely inaccessible. And to make it even worse, because of this, the virtual viewport was extended, causing other non-backtick text to also go out of view.

This fixes the issue by overriding the style to enable wrapping.