### PR TITLE
scope conversations to the project

### DIFF
--- a/src/main/java/ee/carlrobert/codegpt/actions/editor/OpenNewChatAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/actions/editor/OpenNewChatAction.java
@@ -23,7 +23,7 @@ public class OpenNewChatAction extends AnAction {
   public void actionPerformed(@NotNull AnActionEvent event) {
     var project = event.getProject();
     if (project != null) {
-      ConversationsState.getInstance().setCurrentConversation(null);
+      ConversationsState.getInstance(project).setCurrentConversation(null);
       var tabPanel =
           project.getService(ChatToolWindowContentManager.class).createNewTabPanel();
       if (tabPanel != null) {

--- a/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/DeleteAllConversationsAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/DeleteAllConversationsAction.java
@@ -28,7 +28,7 @@ public class DeleteAllConversationsAction extends AnAction {
   public void update(@NotNull AnActionEvent event) {
     var project = event.getProject();
     if (project != null) {
-      var sortedConversations = ConversationService.getInstance().getSortedConversations();
+      var sortedConversations = ConversationService.getInstance(project).getSortedConversations();
       event.getPresentation().setEnabled(!sortedConversations.isEmpty());
     }
   }
@@ -43,7 +43,7 @@ public class DeleteAllConversationsAction extends AnAction {
       var project = event.getProject();
       if (project != null) {
         try {
-          ConversationService.getInstance().clearAll();
+          ConversationService.getInstance(project).clearAll();
           project.getService(ChatToolWindowContentManager.class).resetAll();
         } finally {
           TelemetryAction.IDE_ACTION.createActionMessage()

--- a/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/DeleteConversationAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/DeleteConversationAction.java
@@ -4,6 +4,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import ee.carlrobert.codegpt.actions.ActionType;
 import ee.carlrobert.codegpt.actions.editor.EditorActionsUtil;
@@ -24,7 +25,12 @@ public class DeleteConversationAction extends AnAction {
 
   @Override
   public void update(@NotNull AnActionEvent event) {
-    event.getPresentation().setEnabled(ConversationsState.getCurrentConversation() != null);
+    Project project = event.getProject();
+    if (project == null) {
+      event.getPresentation().setEnabled(false);
+      return;
+    }
+    event.getPresentation().setEnabled(ConversationsState.getInstance(project).getCurrentConversation() != null);
   }
 
   @Override

--- a/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/MoveAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/MoveAction.java
@@ -23,7 +23,12 @@ public abstract class MoveAction extends AnAction {
 
   @Override
   public void update(@NotNull AnActionEvent event) {
-    event.getPresentation().setEnabled(ConversationsState.getCurrentConversation() != null);
+    Project project = event.getProject();
+    if (project == null) {
+      event.getPresentation().setEnabled(false);
+      return;
+    }
+    event.getPresentation().setEnabled(ConversationsState.getInstance(project).getCurrentConversation() != null);
   }
 
   @Override
@@ -32,7 +37,7 @@ public abstract class MoveAction extends AnAction {
     if (project != null) {
       getConversation(project)
           .ifPresent(conversation -> {
-            ConversationsState.getInstance().setCurrentConversation(conversation);
+            ConversationsState.getInstance(project).setCurrentConversation(conversation);
             onRefresh.run();
           });
     }

--- a/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/MoveDownAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/MoveDownAction.java
@@ -17,6 +17,6 @@ public class MoveDownAction extends MoveAction {
 
   @Override
   protected Optional<Conversation> getConversation(@NotNull Project project) {
-    return ConversationService.getInstance().getPreviousConversation();
+    return ConversationService.getInstance(project).getPreviousConversation();
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/MoveUpAction.java
+++ b/src/main/java/ee/carlrobert/codegpt/actions/toolwindow/MoveUpAction.java
@@ -17,6 +17,6 @@ public class MoveUpAction extends MoveAction {
 
   @Override
   protected Optional<Conversation> getConversation(@NotNull Project project) {
-    return ConversationService.getInstance().getNextConversation();
+    return ConversationService.getInstance(project).getNextConversation();
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/conversations/ConversationsState.java
+++ b/src/main/java/ee/carlrobert/codegpt/conversations/ConversationsState.java
@@ -1,9 +1,10 @@
 package ee.carlrobert.codegpt.conversations;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import com.intellij.util.xmlb.annotations.OptionTag;
 import ee.carlrobert.codegpt.conversations.converter.ConversationConverter;
@@ -16,9 +17,10 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@Service(Service.Level.PROJECT)
 @State(
-    name = "ee.carlrobert.codegpt.state.conversations.ConversationsState",
-    storages = @Storage("ChatGPTConversations_170.xml"))
+    name = "ee.carlrobert.codegpt.conversations.ConversationsState",
+    storages = @Storage("proxyai_conversations.xml"))
 public class ConversationsState implements PersistentStateComponent<ConversationsState> {
 
   @Deprecated
@@ -33,8 +35,8 @@ public class ConversationsState implements PersistentStateComponent<Conversation
 
   public boolean discardAllTokenLimits;
 
-  public static ConversationsState getInstance() {
-    return ApplicationManager.getApplication().getService(ConversationsState.class);
+  public static ConversationsState getInstance(@NotNull Project project) {
+    return project.getService(ConversationsState.class);
   }
 
   @Nullable
@@ -65,7 +67,8 @@ public class ConversationsState implements PersistentStateComponent<Conversation
     this.currentConversation = conversation;
   }
 
-  public static @Nullable Conversation getCurrentConversation() {
-    return getInstance().currentConversation;
+  @Nullable
+  public Conversation getCurrentConversation() {
+    return currentConversation;
   }
 }

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowContentManager.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowContentManager.java
@@ -48,7 +48,7 @@ public final class ChatToolWindowContentManager {
         .getState()
         .getChatActions()
         .getStartInNewWindow();
-    if (startInNewWindow || ConversationsState.getCurrentConversation() == null) {
+    if (startInNewWindow || ConversationsState.getInstance(project).getCurrentConversation() == null) {
       createNewTabPanel().sendMessage(message, conversationType);
       return;
     }
@@ -78,7 +78,7 @@ public final class ChatToolWindowContentManager {
         .map(item -> {
           var panel = new ChatToolWindowTabPanel(
               project,
-              ConversationService.getInstance().startConversation(project));
+              ConversationService.getInstance(project).startConversation());
           item.addNewTab(panel);
           return panel;
         })
@@ -117,7 +117,7 @@ public final class ChatToolWindowContentManager {
       tabbedPane.clearAll();
       tabbedPane.addNewTab(new ChatToolWindowTabPanel(
           project,
-          ConversationService.getInstance().startConversation(project)));
+          ConversationService.getInstance(project).startConversation()));
     });
   }
 

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowPanel.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowPanel.java
@@ -62,7 +62,7 @@ public class ChatToolWindowPanel extends SimpleToolWindowPanel {
     upgradePlanLink.setVisible(false);
 
     var tabPanel = new ChatToolWindowTabPanel(project, getConversation());
-    tabbedPane = new ChatToolWindowTabbedPane(parentDisposable);
+    tabbedPane = new ChatToolWindowTabbedPane(project, parentDisposable);
     tabbedPane.addNewTab(tabPanel);
 
     initToolWindowPanel(project);
@@ -72,9 +72,9 @@ public class ChatToolWindowPanel extends SimpleToolWindowPanel {
   }
 
   private Conversation getConversation() {
-    var conversation = ConversationsState.getCurrentConversation();
+    var conversation = ConversationsState.getInstance(project).getCurrentConversation();
     if (conversation == null) {
-      return ConversationService.getInstance().startConversation(project);
+      return ConversationService.getInstance(project).startConversation();
     }
     return conversation;
   }
@@ -120,7 +120,7 @@ public class ChatToolWindowPanel extends SimpleToolWindowPanel {
     Runnable onAddNewTab = () -> {
       tabbedPane.addNewTab(new ChatToolWindowTabPanel(
           project,
-          ConversationService.getInstance().startConversation(project)));
+          ConversationService.getInstance(project).startConversation()));
       repaint();
       revalidate();
     };

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabPanel.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabPanel.java
@@ -89,7 +89,7 @@ public class ChatToolWindowTabPanel implements Disposable {
     this.project = project;
     this.conversation = conversation;
     this.chatSession = new ChatSession();
-    conversationService = ConversationService.getInstance();
+    conversationService = ConversationService.getInstance(project);
     toolWindowScrollablePanel = new ChatToolWindowScrollablePanel();
     tagManager = new TagManager();
     this.psiStructureRepository = new PsiStructureRepository(
@@ -220,6 +220,7 @@ public class ChatToolWindowTabPanel implements Disposable {
         .map(it -> {
           if (it instanceof HistoryTagDetails tagDetails) {
             return ConversationTagProcessor.Companion.getConversation(
+                project,
                 tagDetails.getConversationId());
           }
           return null;

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabbedPane.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabbedPane.java
@@ -26,6 +26,7 @@ import javax.swing.JPopupMenu;
 
 public class ChatToolWindowTabbedPane extends JBTabbedPane {
 
+  private final Project project;
   private final Map<String, ChatToolWindowTabPanel> activeTabMapping = new TreeMap<>(
       (o1, o2) -> {
         String nums1 = o1.replaceAll("\\D", "");
@@ -48,7 +49,8 @@ public class ChatToolWindowTabbedPane extends JBTabbedPane {
       });
   private final Disposable parentDisposable;
 
-  public ChatToolWindowTabbedPane(Disposable parentDisposable) {
+  public ChatToolWindowTabbedPane(Project project, Disposable parentDisposable) {
+    this.project = project;
     this.parentDisposable = parentDisposable;
     setTabComponentInsets(null);
     setComponentPopupMenu(new TabPopupMenu());
@@ -180,7 +182,7 @@ public class ChatToolWindowTabbedPane extends JBTabbedPane {
     if (toolWindowPanel != null) {
       var conversation = toolWindowPanel.getConversation();
       if (conversation != null) {
-        ConversationsState.getInstance().setCurrentConversation(conversation);
+        ConversationsState.getInstance(project).setCurrentConversation(conversation);
       }
     }
   }
@@ -192,7 +194,7 @@ public class ChatToolWindowTabbedPane extends JBTabbedPane {
       removeTabAt(getSelectedIndex());
       addNewTab(new ChatToolWindowTabPanel(
           project,
-          ConversationService.getInstance().startConversation(project)));
+          ConversationService.getInstance(project).startConversation()));
       repaint();
       revalidate();
     });

--- a/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ToolWindowCompletionResponseEventListener.java
+++ b/src/main/java/ee/carlrobert/codegpt/toolwindow/chat/ToolWindowCompletionResponseEventListener.java
@@ -102,13 +102,13 @@ abstract class ToolWindowCompletionResponseEventListener implements
   @Override
   public void handleTokensExceeded(Conversation conversation, Message message) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      var answer = OverlayUtil.showTokenLimitExceededDialog();
+      var answer = OverlayUtil.showTokenLimitExceededDialog(project);
       if (answer == OK) {
         TelemetryAction.IDE_ACTION.createActionMessage()
             .property("action", "DISCARD_TOKEN_LIMIT")
             .send();
 
-        ConversationService.getInstance().discardTokenLimits(conversation);
+        ConversationService.getInstance(project).discardTokenLimits(conversation);
         handleTokensExceededPolicyAccepted();
       } else {
         stopStreaming(responseContainer);
@@ -118,7 +118,7 @@ abstract class ToolWindowCompletionResponseEventListener implements
 
   @Override
   public void handleCompleted(String fullMessage, ChatCompletionParameters callParameters) {
-    ConversationService.getInstance().saveMessage(fullMessage, callParameters);
+    ConversationService.getInstance(project).saveMessage(fullMessage, callParameters);
 
     ApplicationManager.getApplication().invokeLater(() -> {
       try {

--- a/src/main/java/ee/carlrobert/codegpt/ui/OverlayUtil.java
+++ b/src/main/java/ee/carlrobert/codegpt/ui/OverlayUtil.java
@@ -105,7 +105,7 @@ public class OverlayUtil {
         Default);
   }
 
-  public static int showTokenLimitExceededDialog() {
+  public static int showTokenLimitExceededDialog(Project project) {
     return MessageDialogBuilder.okCancel(
             CodeGPTBundle.get("dialog.tokenLimitExceeded.title"),
             CodeGPTBundle.get("dialog.tokenLimitExceeded.description"))
@@ -116,7 +116,7 @@ public class OverlayUtil {
           @Override
           public void rememberChoice(boolean isSelected, int exitCode) {
             if (isSelected) {
-              ConversationsState.getInstance().discardAllTokenLimits();
+              ConversationsState.getInstance(project).discardAllTokenLimits();
             }
           }
 

--- a/src/main/kotlin/ee/carlrobert/codegpt/inlineedit/InlineEditInlay.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/inlineedit/InlineEditInlay.kt
@@ -22,6 +22,7 @@ import ee.carlrobert.codegpt.CodeGPTKeys
 import ee.carlrobert.codegpt.ReferencedFile
 import ee.carlrobert.codegpt.actions.editor.EditorComponentInlaysManager
 import ee.carlrobert.codegpt.conversations.Conversation
+import ee.carlrobert.codegpt.conversations.ConversationService
 import ee.carlrobert.codegpt.conversations.message.Message
 import ee.carlrobert.codegpt.psistructure.PsiStructureProvider
 import ee.carlrobert.codegpt.settings.service.FeatureType
@@ -290,8 +291,8 @@ class InlineEditInlay(private var editor: Editor) : Disposable {
             projectPath = sessionConversation.projectPath
             setMessages(sessionConversation.messages)
         }
-        ee.carlrobert.codegpt.conversations.ConversationService.getInstance().addConversation(newConversation)
-        ee.carlrobert.codegpt.conversations.ConversationService.getInstance().saveConversation(newConversation)
+        ConversationService.getInstance(project).addConversation(newConversation)
+        ConversationService.getInstance(project).saveConversation(newConversation)
         openedChatConversation = newConversation
         project.service<ee.carlrobert.codegpt.toolwindow.chat.ChatToolWindowContentManager>()
             .displayConversation(newConversation)
@@ -526,7 +527,7 @@ class InlineEditInlay(private var editor: Editor) : Disposable {
         return tags
             .filter { it.selected && it is HistoryTagDetails }
             .map { (it as HistoryTagDetails).conversationId }
-            .mapNotNull { ConversationTagProcessor.getConversation(it) }
+            .mapNotNull { ConversationTagProcessor.getConversation(project, it) }
             .distinct()
     }
 

--- a/src/main/kotlin/ee/carlrobert/codegpt/inlineedit/InlineEditSearchReplaceListener.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/inlineedit/InlineEditSearchReplaceListener.kt
@@ -472,8 +472,8 @@ class InlineEditSearchReplaceListener(
             newConversation.addMessage(copy)
         }
 
-        ConversationService.getInstance().addConversation(newConversation)
-        ConversationService.getInstance().saveConversation(newConversation)
+        ConversationService.getInstance(project).addConversation(newConversation)
+        ConversationService.getInstance(project).saveConversation(newConversation)
         project.service<ChatToolWindowContentManager>().displayConversation(newConversation)
     }
 

--- a/src/main/kotlin/ee/carlrobert/codegpt/toolwindow/history/ChatHistoryToolWindow.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/toolwindow/history/ChatHistoryToolWindow.kt
@@ -19,7 +19,6 @@ import ee.carlrobert.codegpt.CodeGPTBundle
 import ee.carlrobert.codegpt.actions.toolwindow.DeleteAllConversationsAction
 import ee.carlrobert.codegpt.conversations.Conversation
 import ee.carlrobert.codegpt.conversations.ConversationService
-import ee.carlrobert.codegpt.conversations.ConversationsState
 import ee.carlrobert.codegpt.toolwindow.chat.ChatToolWindowContentManager
 import ee.carlrobert.codegpt.util.ProjectPathUtils
 import javax.swing.JOptionPane
@@ -37,7 +36,7 @@ class ChatHistoryToolWindow(private val project: Project) : BorderLayoutPanel() 
         private const val MAX_MESSAGES_TO_SEARCH = 5
     }
 
-    private val conversationService = ConversationService.getInstance()
+    private val conversationService = project.getService(ConversationService::class.java)
     private val chatHistoryListPanel = ChatHistoryListPanel()
     private val searchField = SearchTextField()
     private var allConversations = mutableListOf<Conversation>()
@@ -106,7 +105,7 @@ class ChatHistoryToolWindow(private val project: Project) : BorderLayoutPanel() 
     private fun setupUI() {
         chatHistoryListPanel.apply {
             setOnConversationSelected { conversation ->
-                ConversationsState.getInstance().setCurrentConversation(conversation)
+                conversationService.saveConversation(conversation)
             }
 
             setOnConversationDoubleClicked { conversation ->
@@ -580,7 +579,7 @@ class ChatHistoryToolWindow(private val project: Project) : BorderLayoutPanel() 
     }
 
     private fun updateSelectedConversation(conversations: List<Conversation>) {
-        ConversationsState.getCurrentConversation()?.let { current ->
+        conversationService.currentConversation?.let { current ->
             conversations.find { it.id == current.id }?.let { conversation ->
                 chatHistoryListPanel.setSelectedConversation(conversation)
             }

--- a/src/main/kotlin/ee/carlrobert/codegpt/toolwindow/ui/UserMessagePanel.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/toolwindow/ui/UserMessagePanel.kt
@@ -181,7 +181,7 @@ class UserMessagePanel(
                     layout = BoxLayout(this, BoxLayout.Y_AXIS)
                     isOpaque = false
                     ids.forEach {
-                        ConversationTagProcessor.getConversation(it)?.let { conversation ->
+                        ConversationTagProcessor.getConversation(project, it)?.let { conversation ->
                             val title = HistoryActionItem.getConversationTitle(conversation)
                             val titleLink = ActionLink(title) {
                                 project.service<ChatToolWindowContentManager>()

--- a/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/SearchManager.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/SearchManager.kt
@@ -39,7 +39,7 @@ class SearchManager(
         FilesGroupItem(project, tagManager),
         FoldersGroupItem(project, tagManager),
         GitGroupItem(project),
-        HistoryGroupItem(),
+        HistoryGroupItem(project),
         DiagnosticsActionItem(tagManager)
     ).filter { it.enabled }
 
@@ -47,7 +47,7 @@ class SearchManager(
         FilesGroupItem(project, tagManager),
         FoldersGroupItem(project, tagManager),
         GitGroupItem(project),
-        HistoryGroupItem(),
+        HistoryGroupItem(project),
         PersonasGroupItem(tagManager),
         DocsGroupItem(tagManager),
         CodeAnalyzeActionItem(tagManager),

--- a/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/TagProcessorFactory.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/TagProcessorFactory.kt
@@ -228,11 +228,10 @@ class ConversationTagProcessor(
 ) : TagProcessor {
 
     companion object {
-        fun getConversation(conversationId: UUID) =
-            ConversationsState.getCurrentConversation()?.takeIf {
-                it.id.equals(conversationId)
-            } ?: ConversationsState.getInstance().conversations.find {
-                it.id.equals(conversationId)
+        fun getConversation(project: Project, conversationId: UUID): Conversation? {
+            val state = ConversationsState.getInstance(project)
+            return state.currentConversation?.takeIf { it.id == conversationId }
+                ?: state.conversations.find { it.id == conversationId }
             }
 
         fun formatConversation(conversation: Conversation): String {

--- a/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/lookup/group/HistoryGroupItem.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/lookup/group/HistoryGroupItem.kt
@@ -3,6 +3,7 @@ package ee.carlrobert.codegpt.ui.textarea.lookup.group
 import com.intellij.codeInsight.lookup.impl.LookupImpl
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.project.Project
 import ee.carlrobert.codegpt.CodeGPTBundle
 import ee.carlrobert.codegpt.conversations.ConversationsState
 import ee.carlrobert.codegpt.ui.textarea.lookup.DynamicLookupGroupItem
@@ -12,7 +13,7 @@ import ee.carlrobert.codegpt.ui.textarea.lookup.action.HistoryActionItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class HistoryGroupItem : AbstractLookupGroupItem(), DynamicLookupGroupItem {
+class HistoryGroupItem(private val project: Project) : AbstractLookupGroupItem(), DynamicLookupGroupItem {
 
     override val displayName: String =
         CodeGPTBundle.get("suggestionGroupItem.history.displayName")
@@ -21,7 +22,7 @@ class HistoryGroupItem : AbstractLookupGroupItem(), DynamicLookupGroupItem {
     private val addedItems = mutableSetOf<String>()
 
     override suspend fun getLookupItems(searchText: String): List<LookupActionItem> {
-        return ConversationsState.getInstance().conversations
+        return ConversationsState.getInstance(project).conversations
             .sortedByDescending { it.updatedOn }
             .filter { conversation ->
                 if (searchText.isEmpty()) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,7 +44,7 @@
         <applicationConfigurable id="settings.codegpt.services.anthropic" parentId="settings.codegpt.services"
                                  displayName="Anthropic"
                                  instance="ee.carlrobert.codegpt.settings.service.AnthropicServiceConfigurable"/>
-        <applicationConfigurable id="settings.codegpt.services.google" parentId="settings.codegpt.services"
+        <applicationConfigurable id="settings.codegegpt.services.google" parentId="settings.codegpt.services"
                                  displayName="Google"
                                  instance="ee.carlrobert.codegpt.settings.service.google.GoogleSettingsConfigurable"/>
         <applicationConfigurable id="settings.codegpt.services.mistral" parentId="settings.codegpt.services"
@@ -94,7 +94,8 @@
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.models.ModelSettings"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.IncludedFilesSettings"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.settings.advanced.AdvancedSettings"/>
-        <applicationService serviceImplementation="ee.carlrobert.codegpt.conversations.ConversationsState"/>
+        <projectService serviceImplementation="ee.carlrobert.codegpt.conversations.ConversationsState"/>
+        <projectService serviceImplementation="ee.carlrobert.codegpt.conversations.ConversationService"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.codecompletions.psi.CompletionContextService"/>
         <applicationService serviceImplementation="ee.carlrobert.codegpt.services.llama.ServerLogsManager"/>
         <projectService serviceImplementation="ee.carlrobert.codegpt.services.ExecutableRunnerService"/>

--- a/src/test/kotlin/ee/carlrobert/codegpt/completions/CompletionRequestProviderTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/completions/CompletionRequestProviderTest.kt
@@ -23,7 +23,7 @@ class CompletionRequestProviderTest : IntegrationTest() {
             instructions = "TEST_SYSTEM_PROMPT"
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val firstMessage = createDummyMessage(500)
         val secondMessage = createDummyMessage(250)
         conversation.addMessage(firstMessage)
@@ -56,7 +56,7 @@ class CompletionRequestProviderTest : IntegrationTest() {
             instructions = "TEST_SYSTEM_PROMPT"
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val firstMessage = createDummyMessage("FIRST_TEST_PROMPT", 500)
         val secondMessage = createDummyMessage("SECOND_TEST_PROMPT", 250)
         conversation.addMessage(firstMessage)

--- a/src/test/kotlin/ee/carlrobert/codegpt/completions/DefaultToolwindowChatCompletionRequestHandlerTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/completions/DefaultToolwindowChatCompletionRequestHandlerTest.kt
@@ -27,7 +27,7 @@ class DefaultToolwindowChatCompletionRequestHandlerTest : IntegrationTest() {
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
         val message = Message("TEST_PROMPT")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         expectOpenAI(StreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/chat/completions")
             assertThat(request.method).isEqualTo("POST")
@@ -74,7 +74,7 @@ class DefaultToolwindowChatCompletionRequestHandlerTest : IntegrationTest() {
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
         val message = Message("TEST_PROMPT")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         conversation.addMessage(Message("Ping", "Pong"))
         expectLlama(StreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/chat/completions")
@@ -122,7 +122,7 @@ class DefaultToolwindowChatCompletionRequestHandlerTest : IntegrationTest() {
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
         val message = Message("TEST_PROMPT")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         expectOllama(NdJsonStreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/chat/completions")
             assertThat(request.method).isEqualTo("POST")
@@ -170,7 +170,7 @@ class DefaultToolwindowChatCompletionRequestHandlerTest : IntegrationTest() {
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
         val message = Message("TEST_PROMPT")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         expectGoogle(StreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/models/gemini-2.0-flash:streamGenerateContent")
             assertThat(request.method).isEqualTo("POST")
@@ -218,7 +218,7 @@ class DefaultToolwindowChatCompletionRequestHandlerTest : IntegrationTest() {
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
         val message = Message("TEST_PROMPT")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         expectCodeGPT(StreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/chat/completions")
             assertThat(request.method).isEqualTo("POST")

--- a/src/test/kotlin/ee/carlrobert/codegpt/completions/OpenAIRequestFactoryIntegrationTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/completions/OpenAIRequestFactoryIntegrationTest.kt
@@ -24,7 +24,7 @@ class OpenAIRequestFactoryIntegrationTest : IntegrationTest() {
     fun testDefaultPersonaUsesEditModePromptWhenEnabled() {
         useOpenAIService(OpenAIChatCompletionModel.GPT_4_O.code)
         service<PromptsSettings>().state.personas.selectedPersona = PersonasState.DEFAULT_PERSONA
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val message = Message("Please refactor this code")
         val callParameters = ChatCompletionParameters
             .builder(conversation, message)
@@ -129,7 +129,7 @@ class OpenAIRequestFactoryIntegrationTest : IntegrationTest() {
     fun testDefaultPersonaIsFilteredInAskMode() {
         useOpenAIService(OpenAIChatCompletionModel.GPT_4_O.code)
         service<PromptsSettings>().state.personas.selectedPersona = PersonasState.DEFAULT_PERSONA
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val message = Message("Please refactor this code")
         val callParameters = ChatCompletionParameters
             .builder(conversation, message)
@@ -248,7 +248,7 @@ class OpenAIRequestFactoryIntegrationTest : IntegrationTest() {
             instructions = personaPromptWithSearchReplace
         }
         service<PromptsSettings>().state.personas.selectedPersona = customPersona
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val message = Message("Please refactor this code")
         val callParameters = ChatCompletionParameters
             .builder(conversation, message)
@@ -293,7 +293,7 @@ class OpenAIRequestFactoryIntegrationTest : IntegrationTest() {
         """.trimIndent()
         service<PromptsSettings>().state.personas.selectedPersona.instructions =
             personaPromptWithSearchReplace
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val message = Message("Please refactor this code")
         val callParameters = ChatCompletionParameters
             .builder(conversation, message)

--- a/src/test/kotlin/ee/carlrobert/codegpt/conversations/ConversationsStateTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/conversations/ConversationsStateTest.kt
@@ -2,22 +2,18 @@ package ee.carlrobert.codegpt.conversations
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import ee.carlrobert.codegpt.conversations.message.Message
-import ee.carlrobert.codegpt.settings.GeneralSettings
-import ee.carlrobert.codegpt.settings.service.ServiceType
-import ee.carlrobert.codegpt.settings.service.openai.OpenAISettings
-import ee.carlrobert.llm.client.openai.completion.OpenAIChatCompletionModel
 import org.assertj.core.api.Assertions.assertThat
 
 class ConversationsStateTest : BasePlatformTestCase() {
 
   fun testStartNewDefaultConversation() {
-    val conversation = ConversationService.getInstance().startConversation(project)
+    val conversation = ConversationService.getInstance(project).startConversation()
 
-    assertThat(conversation).isEqualTo(ConversationsState.getCurrentConversation())
+    assertThat(conversation).isEqualTo(ConversationService.getInstance(project).currentConversation)
   }
 
   fun testSaveConversation() {
-    val service = ConversationService.getInstance()
+    val service = ConversationService.getInstance(project)
     val conversation = service.createConversation()
     service.addConversation(conversation)
     val message = Message("TEST_PROMPT")
@@ -26,7 +22,7 @@ class ConversationsStateTest : BasePlatformTestCase() {
 
     service.saveConversation(conversation)
 
-    val currentConversation = ConversationsState.getCurrentConversation()
+    val currentConversation = ConversationService.getInstance(project).currentConversation
     assertThat(currentConversation).isNotNull()
     assertThat(currentConversation!!.messages)
       .flatExtracting("prompt", "response")
@@ -34,9 +30,9 @@ class ConversationsStateTest : BasePlatformTestCase() {
   }
 
   fun testGetPreviousConversation() {
-    val service = ConversationService.getInstance()
-    val firstConversation = service.startConversation(project)
-    service.startConversation(project)
+    val service = ConversationService.getInstance(project)
+    val firstConversation = service.startConversation()
+    service.startConversation()
 
     val previousConversation = service.previousConversation
 
@@ -45,10 +41,10 @@ class ConversationsStateTest : BasePlatformTestCase() {
   }
 
   fun testGetNextConversation() {
-    val service = ConversationService.getInstance()
-    val firstConversation = service.startConversation(project)
-    val secondConversation = service.startConversation(project)
-    ConversationsState.getInstance().setCurrentConversation(firstConversation)
+    val service = ConversationService.getInstance(project)
+    val firstConversation = service.startConversation()
+    val secondConversation = service.startConversation()
+    ConversationsState.getInstance(project).setCurrentConversation(firstConversation)
 
     val nextConversation = service.nextConversation
 
@@ -57,13 +53,13 @@ class ConversationsStateTest : BasePlatformTestCase() {
   }
 
   fun testDeleteSelectedConversation() {
-    val service = ConversationService.getInstance()
-    val firstConversation = service.startConversation(project)
-    service.startConversation(project)
+    val service = ConversationService.getInstance(project)
+    val firstConversation = service.startConversation()
+    service.startConversation()
 
     service.deleteSelectedConversation()
 
-    assertThat(ConversationsState.getCurrentConversation()).isEqualTo(firstConversation)
+    assertThat(ConversationService.getInstance(project).currentConversation).isEqualTo(firstConversation)
     assertThat(service.sortedConversations.size).isEqualTo(1)
     assertThat(service.sortedConversations)
       .extracting("id")
@@ -71,13 +67,13 @@ class ConversationsStateTest : BasePlatformTestCase() {
   }
 
   fun testClearAllConversations() {
-    val service = ConversationService.getInstance()
-    service.startConversation(project)
-    service.startConversation(project)
+    val service = ConversationService.getInstance(project)
+    service.startConversation()
+    service.startConversation()
 
     service.clearAll()
 
-    assertThat(ConversationsState.getCurrentConversation()).isNull()
+    assertThat(ConversationService.getInstance(project).currentConversation).isNull()
     assertThat(service.sortedConversations.size).isEqualTo(0)
   }
 }

--- a/src/test/kotlin/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabPanelTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabPanelTest.kt
@@ -31,7 +31,7 @@ class ChatToolWindowTabPanelTest : IntegrationTest() {
         service<PromptsSettings>().state.personas.selectedPersona.instructions =
             "TEST_SYSTEM_PROMPT"
         val message = Message("Hello!")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val panel = ChatToolWindowTabPanel(project, conversation)
         expectOpenAI(StreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/chat/completions")
@@ -100,7 +100,7 @@ class ChatToolWindowTabPanelTest : IntegrationTest() {
         val message = Message("TEST_MESSAGE")
         message.referencedFilePaths =
             listOf("TEST_FILE_PATH_1", "TEST_FILE_PATH_2", "TEST_FILE_PATH_3")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val panel = ChatToolWindowTabPanel(project, conversation)
         panel.includeFiles(listOf(
             LightVirtualFile("TEST_FILE_NAME_1", "TEST_FILE_CONTENT_1"),
@@ -201,7 +201,7 @@ class ChatToolWindowTabPanelTest : IntegrationTest() {
         service<PromptsSettings>().state.personas.selectedPersona.instructions =
             "TEST_SYSTEM_PROMPT"
         val message = Message("TEST_MESSAGE")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val panel = ChatToolWindowTabPanel(project, conversation)
         expectOpenAI(StreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/chat/completions")
@@ -287,7 +287,7 @@ class ChatToolWindowTabPanelTest : IntegrationTest() {
         val message = Message("TEST_MESSAGE")
         message.referencedFilePaths =
             listOf("TEST_FILE_PATH_1", "TEST_FILE_PATH_2", "TEST_FILE_PATH_3")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val panel = ChatToolWindowTabPanel(project, conversation)
         panel.includeFiles(
             listOf(
@@ -398,7 +398,7 @@ class ChatToolWindowTabPanelTest : IntegrationTest() {
         llamaSettings.minP = 0.03
         llamaSettings.repeatPenalty = 1.3
         val message = Message("TEST_PROMPT")
-        val conversation = ConversationService.getInstance().startConversation(project)
+        val conversation = ConversationService.getInstance(project).startConversation()
         val panel = ChatToolWindowTabPanel(project, conversation)
         expectLlama(StreamHttpExchange { request: RequestEntity ->
             assertThat(request.uri.path).isEqualTo("/v1/chat/completions")

--- a/src/test/kotlin/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabbedPaneTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/toolwindow/chat/ChatToolWindowTabbedPaneTest.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 class ChatToolWindowTabbedPaneTest : BasePlatformTestCase() {
 
   fun testClearAllTabs() {
-    val tabbedPane = ChatToolWindowTabbedPane(Disposer.newDisposable())
+    val tabbedPane = ChatToolWindowTabbedPane(project, Disposer.newDisposable())
     tabbedPane.addNewTab(createNewTabPanel())
 
     tabbedPane.clearAll()
@@ -19,7 +19,7 @@ class ChatToolWindowTabbedPaneTest : BasePlatformTestCase() {
 
 
   fun testAddingNewTabs() {
-    val tabbedPane = ChatToolWindowTabbedPane(Disposer.newDisposable())
+    val tabbedPane = ChatToolWindowTabbedPane(project, Disposer.newDisposable())
 
     tabbedPane.addNewTab(createNewTabPanel())
     tabbedPane.addNewTab(createNewTabPanel())
@@ -30,8 +30,8 @@ class ChatToolWindowTabbedPaneTest : BasePlatformTestCase() {
   }
 
   fun testResetCurrentlyActiveTabPanel() {
-    val tabbedPane = ChatToolWindowTabbedPane(Disposer.newDisposable())
-    val conversation = ConversationService.getInstance().startConversation(project)
+    val tabbedPane = ChatToolWindowTabbedPane(project, Disposer.newDisposable())
+    val conversation = ConversationService.getInstance(project).startConversation()
     conversation.addMessage(Message("TEST_PROMPT", "TEST_RESPONSE"))
     tabbedPane.addNewTab(ChatToolWindowTabPanel(project, conversation))
 
@@ -44,7 +44,7 @@ class ChatToolWindowTabbedPaneTest : BasePlatformTestCase() {
   private fun createNewTabPanel(): ChatToolWindowTabPanel {
     return ChatToolWindowTabPanel(
       project,
-      ConversationService.getInstance().startConversation(project)
+      ConversationService.getInstance(project).startConversation()
     )
   }
 }

--- a/src/test/kotlin/ee/carlrobert/codegpt/ui/textarea/ConversationTagProcessorTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/ui/textarea/ConversationTagProcessorTest.kt
@@ -15,8 +15,8 @@ class ConversationTagProcessorTest : IntegrationTest() {
 
     public override fun setUp() {
         super.setUp()
-        conversationService = service<ConversationService>()
-        ConversationsState.getInstance().conversations.clear()
+        conversationService = project.service<ConversationService>()
+        ConversationsState.getInstance(project).conversations.clear()
     }
 
     fun `test should format conversation with single message`() {
@@ -100,12 +100,12 @@ class ConversationTagProcessorTest : IntegrationTest() {
     }
 
     fun `test should find current conversation by id`() {
-        val conversation = conversationService.startConversation(project)
+        val conversation = conversationService.startConversation()
         conversation.addMessage(Message("Current conversation test").apply {
             response = "This is the current conversation"
         })
 
-        val foundConversation = ConversationTagProcessor.getConversation(conversation.id)
+        val foundConversation = ConversationTagProcessor.getConversation(project, conversation.id)
 
         assertThat(foundConversation).isNotNull
         assertThat(foundConversation!!.id).isEqualTo(conversation.id)
@@ -120,7 +120,7 @@ class ConversationTagProcessorTest : IntegrationTest() {
         })
         conversationService.addConversation(conversation)
 
-        val foundConversation = ConversationTagProcessor.getConversation(conversation.id)
+        val foundConversation = ConversationTagProcessor.getConversation(project, conversation.id)
 
         assertThat(foundConversation).isNotNull
         assertThat(foundConversation!!.id).isEqualTo(conversation.id)
@@ -134,13 +134,13 @@ class ConversationTagProcessorTest : IntegrationTest() {
             response = "This is stored"
         })
         conversationService.addConversation(storedConversation)
-        val currentConversation = conversationService.startConversation(project)
+        val currentConversation = conversationService.startConversation()
         currentConversation.id = storedConversation.id
         currentConversation.addMessage(Message("Current version").apply {
             response = "This is current"
         })
 
-        val foundConversation = ConversationTagProcessor.getConversation(storedConversation.id)
+        val foundConversation = ConversationTagProcessor.getConversation(project, storedConversation.id)
 
         assertThat(foundConversation).isNotNull
         assertThat(foundConversation!!.messages[0].prompt).isEqualTo("Current version")
@@ -149,7 +149,7 @@ class ConversationTagProcessorTest : IntegrationTest() {
     fun `test should return null for non-existent conversation`() {
         val nonExistentId = UUID.randomUUID()
 
-        val foundConversation = ConversationTagProcessor.getConversation(nonExistentId)
+        val foundConversation = ConversationTagProcessor.getConversation(project, nonExistentId)
 
         assertThat(foundConversation).isNull()
     }
@@ -161,7 +161,7 @@ class ConversationTagProcessorTest : IntegrationTest() {
         })
         conversationService.addConversation(conversation)
         val historyActionItem = HistoryActionItem(conversation)
-        val foundConversation = ConversationTagProcessor.getConversation(conversation.id)
+        val foundConversation = ConversationTagProcessor.getConversation(project, conversation.id)
 
         val conversationTitle = historyActionItem.displayName
         val formatted = ConversationTagProcessor.formatConversation(foundConversation!!)

--- a/src/test/kotlin/ee/carlrobert/codegpt/ui/textarea/HistorySearchIntegrationTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/ui/textarea/HistorySearchIntegrationTest.kt
@@ -19,12 +19,12 @@ class HistorySearchIntegrationTest : IntegrationTest() {
 
     public override fun setUp() {
         super.setUp()
-        conversationService = service<ConversationService>()
-        ConversationsState.getInstance().conversations.clear()
-        
+        conversationService = project.service<ConversationService>()
+        ConversationsState.getInstance(project).conversations.clear()
+
         val tagManager = TagManager()
         searchManager = SearchManager(project, tagManager)
-        historyGroupItem = HistoryGroupItem()
+        historyGroupItem = HistoryGroupItem(project)
     }
 
     fun `test should include history group in search manager default groups`() {
@@ -44,7 +44,7 @@ class HistorySearchIntegrationTest : IntegrationTest() {
     }
 
     fun `test should filter conversations by search terms`() {
-        ConversationsState.getInstance().conversations.clear()
+        ConversationsState.getInstance(project).conversations.clear()
         createTestConversations()
         val testCases = mapOf(
             "java" to 3,
@@ -88,8 +88,8 @@ class HistorySearchIntegrationTest : IntegrationTest() {
 
     fun `test should handle special characters in search`() {
         val conversation = conversationService.createConversation()
-        conversation.addMessage(Message("What is C++ programming?").apply { 
-            response = "C++ is a powerful programming language" 
+        conversation.addMessage(Message("What is C++ programming?").apply {
+            response = "C++ is a powerful programming language"
         })
         conversationService.addConversation(conversation)
 
@@ -104,13 +104,13 @@ class HistorySearchIntegrationTest : IntegrationTest() {
             val conversation = conversationService.createConversation()
             val topic = when (i % 5) {
                 0 -> "Java"
-                1 -> "Python" 
+                1 -> "Python"
                 2 -> "JavaScript"
                 3 -> "Database"
                 else -> "General"
             }
-            conversation.addMessage(Message("Question about $topic #$i").apply { 
-                response = "Answer about $topic #$i" 
+            conversation.addMessage(Message("Question about $topic #$i").apply {
+                response = "Answer about $topic #$i"
             })
             conversationService.addConversation(conversation)
         }
@@ -139,13 +139,13 @@ class HistorySearchIntegrationTest : IntegrationTest() {
 
     fun `test should search in conversation titles`() {
         val conversation1 = conversationService.createConversation()
-        conversation1.addMessage(Message("How to use Docker containers?").apply { 
-            response = "Docker containers are lightweight virtualization" 
+        conversation1.addMessage(Message("How to use Docker containers?").apply {
+            response = "Docker containers are lightweight virtualization"
         })
         conversationService.addConversation(conversation1)
         val conversation2 = conversationService.createConversation()
-        conversation2.addMessage(Message("What is virtualization?").apply { 
-            response = "Virtualization allows running multiple Docker instances" 
+        conversation2.addMessage(Message("What is virtualization?").apply {
+            response = "Virtualization allows running multiple Docker instances"
         })
         conversationService.addConversation(conversation2)
 
@@ -160,7 +160,7 @@ class HistorySearchIntegrationTest : IntegrationTest() {
 
     fun `test should match history aliases in search manager`() {
         val historyAliases = listOf("history", "hist", "h")
-        
+
         historyAliases.forEach { alias ->
             val matches = searchManager.matchesAnyDefaultGroup(alias)
             assertThat(matches)
@@ -178,7 +178,7 @@ class HistorySearchIntegrationTest : IntegrationTest() {
     private fun createTestConversations() {
         val testData = listOf(
             "How to write Java code?" to "Use Java syntax and compile with javac",
-            "Python vs JavaScript comparison" to "Python is interpreted, JavaScript runs in browsers", 
+            "Python vs JavaScript comparison" to "Python is interpreted, JavaScript runs in browsers",
             "What is database normalization?" to "Database normalization reduces redundancy",
             "Best practices for programming" to "Write clean, readable, and testable code",
             "JavaScript async/await tutorial" to "Use async/await for asynchronous programming"

--- a/src/test/kotlin/ee/carlrobert/codegpt/ui/textarea/HistoryTagIntegrationTest.kt
+++ b/src/test/kotlin/ee/carlrobert/codegpt/ui/textarea/HistoryTagIntegrationTest.kt
@@ -21,8 +21,8 @@ class HistoryTagIntegrationTest : IntegrationTest() {
 
     public override fun setUp() {
         super.setUp()
-        conversationService = service<ConversationService>()
-        ConversationsState.getInstance().conversations.clear()
+        conversationService = project.service<ConversationService>()
+        ConversationsState.getInstance(project).conversations.clear()
     }
 
     fun testShouldDisplayCorrectNameForHistoryActionItem() {
@@ -88,7 +88,7 @@ class HistoryTagIntegrationTest : IntegrationTest() {
     }
 
     fun testShouldFilterConversationsBySearchText() {
-        val historyGroupItem = HistoryGroupItem()
+        val historyGroupItem = HistoryGroupItem(project)
         val javaConversation = conversationService.createConversation()
         javaConversation.addMessage(Message("How to write Java code?").apply { response = "Use Java syntax" })
         conversationService.addConversation(javaConversation)
@@ -106,7 +106,7 @@ class HistoryTagIntegrationTest : IntegrationTest() {
     }
 
     fun testShouldHandleEmptyConversationsList() {
-        val historyGroupItem = HistoryGroupItem()
+        val historyGroupItem = HistoryGroupItem(project)
 
         val results = runBlocking { historyGroupItem.getLookupItems("") }
 
@@ -114,7 +114,7 @@ class HistoryTagIntegrationTest : IntegrationTest() {
     }
 
     fun testShouldPerformCaseInsensitiveSearch() {
-        val historyGroupItem = HistoryGroupItem()
+        val historyGroupItem = HistoryGroupItem(project)
         val conversation = conversationService.createConversation()
         conversation.addMessage(Message("JavaScript Tutorial").apply { response = "Learn JS" })
         conversationService.addConversation(conversation)
@@ -165,7 +165,7 @@ class HistoryTagIntegrationTest : IntegrationTest() {
         conversation.addMessage(Message("Test question").apply { response = "Test answer" })
         conversationService.addConversation(conversation)
 
-        val foundConversation = ConversationTagProcessor.getConversation(conversation.id)
+        val foundConversation = ConversationTagProcessor.getConversation(project, conversation.id)
 
         assertThat(foundConversation).isNotNull
         assertThat(foundConversation!!.id).isEqualTo(conversation.id)
@@ -176,7 +176,7 @@ class HistoryTagIntegrationTest : IntegrationTest() {
     fun testShouldReturnNullForNonExistentConversation() {
         val nonExistentId = UUID.randomUUID()
 
-        val foundConversation = ConversationTagProcessor.getConversation(nonExistentId)
+        val foundConversation = ConversationTagProcessor.getConversation(project, nonExistentId)
 
         assertThat(foundConversation).isNull()
     }
@@ -208,7 +208,7 @@ class HistoryTagIntegrationTest : IntegrationTest() {
     }
 
     fun testShouldSortConversationsByUpdatedDateDescending() {
-        val historyGroupItem = HistoryGroupItem()
+        val historyGroupItem = HistoryGroupItem(project)
         val now = LocalDateTime.now()
         val oldConversation = conversationService.createConversation()
         oldConversation.updatedOn = now.minusDays(3)


### PR DESCRIPTION
Previously conversations were shared among all projects. However even this wasn't working correctly. For example, if you had an conversation in one project, but then opened another project, the conversation would be visible in both. But if you added messages to the conversation, it wouldn't update in the other project. Also sometimes you could open a project, and the conversations weren't there at all. And then if you closed that project, it would nuke the conversations in other projects.

This addresses the issues by making all conversations scoped to the project.