### PR TITLE
add middle-click to remove files from context.

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/header/tag/TagPanel.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/ui/textarea/header/tag/TagPanel.kt
@@ -87,18 +87,13 @@ abstract class TagPanel(
         label.inheritsPopupMenu = true
         closeButton.inheritsPopupMenu = true
 
-        label.addMouseListener(object : MouseAdapter() {
+        val mouseAdapter = object : MouseAdapter() {
             override fun mousePressed(e: MouseEvent) {
-                if (SwingUtilities.isLeftMouseButton(e)) {
-                    this@TagPanel.doClick()
-                    e.consume()
-                }
-                if (SwingUtilities.isMiddleMouseButton(e) && tagDetails.isRemovable) {
-                    onClose()
-                    e.consume()
-                }
+                handleMousePress(e)
             }
-        })
+        }
+        label.addMouseListener(mouseAdapter)
+        addMouseListener(mouseAdapter)
 
         addActionListener {
             if (isRevertingSelection) return@addActionListener
@@ -118,6 +113,17 @@ abstract class TagPanel(
 
         revalidate()
         repaint()
+    }
+
+    private fun handleMousePress(e: MouseEvent) {
+        if (SwingUtilities.isLeftMouseButton(e)) {
+            this@TagPanel.doClick()
+            e.consume()
+        }
+        if (SwingUtilities.isMiddleMouseButton(e) && tagDetails.isRemovable) {
+            onClose()
+            e.consume()
+        }
     }
 
     private fun toProjectRelative(path: String): String? {


### PR DESCRIPTION
Previously when you wanted to remove files which were previously added to the chat context, you had to click the little "x" icon one by one. When you had several files to remove, this got tedious and difficult, especially since the file box varies in width, so the "x" is not in the same space.

This change makes this operation easier by allowing you to middle-click anywhere on the file box to remove it.