### PR TITLE
make the send shortcut configurable

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/configuration/ChatCompletionConfigurationForm.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/configuration/ChatCompletionConfigurationForm.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import ee.carlrobert.codegpt.CodeGPTBundle
+import java.awt.Toolkit
 
 class ChatCompletionConfigurationForm {
 
@@ -27,6 +28,21 @@ class ChatCompletionConfigurationForm {
     private val clickableLinksCheckBox = JBCheckBox(
         CodeGPTBundle.get("configurationConfigurable.section.chatCompletion.clickableLinks.title"),
         service<ConfigurationSettings>().state.chatCompletionSettings.clickableLinksEnabled
+    )
+
+    private val sendWithAltEnterCheckBox = JBCheckBox(
+        Toolkit.getProperty("AWT.alt", "Alt"),
+        service<ConfigurationSettings>().state.chatCompletionSettings.sendWithAltEnter
+    )
+
+    private val sendWithCtrlEnterCheckBox = JBCheckBox(
+        Toolkit.getProperty("AWT.ctrl", "Ctrl"),
+        service<ConfigurationSettings>().state.chatCompletionSettings.sendWithCtrlEnter
+    )
+
+    private val sendWithShiftEnterCheckBox = JBCheckBox(
+        Toolkit.getProperty("AWT.shift", "Shift"),
+        service<ConfigurationSettings>().state.chatCompletionSettings.sendWithShiftEnter
     )
 
     fun createPanel(): DialogPanel {
@@ -50,6 +66,20 @@ class ChatCompletionConfigurationForm {
                 cell(psiStructureAnalyzeDepthField)
                     .comment(CodeGPTBundle.get("configurationConfigurable.section.chatCompletion.psiStructure.analyzeDepth.comment"))
             }
+            group(CodeGPTBundle.get("configurationConfigurable.section.chatCompletion.sendMessageShortcut.title")) {
+                row {
+                    comment(CodeGPTBundle.get("configurationConfigurable.section.chatCompletion.sendMessageShortcut.description"))
+                }
+                row {
+                    cell(sendWithCtrlEnterCheckBox)
+                }
+                row {
+                    cell(sendWithAltEnterCheckBox)
+                }
+                row {
+                    cell(sendWithShiftEnterCheckBox)
+                }
+            }
         }.withBorder(JBUI.Borders.emptyLeft(16))
     }
 
@@ -58,6 +88,9 @@ class ChatCompletionConfigurationForm {
         psiStructureCheckBox.isSelected = prevState.psiStructureEnabled
         psiStructureAnalyzeDepthField.number = prevState.psiStructureAnalyzeDepth
         clickableLinksCheckBox.isSelected = prevState.clickableLinksEnabled
+        sendWithAltEnterCheckBox.isSelected = prevState.sendWithAltEnter
+        sendWithCtrlEnterCheckBox.isSelected = prevState.sendWithCtrlEnter
+        sendWithShiftEnterCheckBox.isSelected = prevState.sendWithShiftEnter
     }
 
     fun getFormState(): ChatCompletionSettingsState {
@@ -66,6 +99,9 @@ class ChatCompletionConfigurationForm {
             this.psiStructureEnabled = psiStructureCheckBox.isSelected
             this.psiStructureAnalyzeDepth = psiStructureAnalyzeDepthField.number
             this.clickableLinksEnabled = clickableLinksCheckBox.isSelected
+            this.sendWithAltEnter = sendWithAltEnterCheckBox.isSelected
+            this.sendWithCtrlEnter = sendWithCtrlEnterCheckBox.isSelected
+            this.sendWithShiftEnter = sendWithShiftEnterCheckBox.isSelected
         }
     }
 }

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/configuration/ConfigurationSettings.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/configuration/ConfigurationSettings.kt
@@ -50,6 +50,9 @@ class ChatCompletionSettingsState : BaseState() {
     var psiStructureEnabled by property(true)
     var psiStructureAnalyzeDepth by property(3)
     var clickableLinksEnabled by property(true)
+    var sendWithAltEnter by property(false)
+    var sendWithCtrlEnter by property(false)
+    var sendWithShiftEnter by property(false)
 }
 
 class CodeCompletionSettingsState : BaseState() {

--- a/src/main/resources/messages/codegpt.properties
+++ b/src/main/resources/messages/codegpt.properties
@@ -168,6 +168,8 @@ configurationConfigurable.section.chatCompletion.psiStructure.analyzeDepth.comme
 configurationConfigurable.section.chatCompletion.psiStructure.description=If enabled, the class structure that is present in the imports of the attached files will be added in the context of the dialog. A structure refers to the source code in files that include constructors, fields, and methods, with all modifiers, arguments, and return types, but without an implementation. The implementation of dependencies is intentionally excluded in order to find a balance between a high-quality chat context and saving tokens.
 configurationConfigurable.section.chatCompletion.clickableLinks.title=Show clickable links for classes and methods
 configurationConfigurable.section.chatCompletion.clickableLinks.description=If enabled, code references in answers become clickable so you can jump to them in your IDE.
+configurationConfigurable.section.chatCompletion.sendMessageShortcut.title=Send Message Shortcut
+configurationConfigurable.section.chatCompletion.sendMessageShortcut.description=If none are selected, 'Enter' by itself sends the message. If any are selected, the chosen shortcut plus 'Enter' sends the message and 'Enter' by itself inserts a newline.
 settingsConfigurable.service.llama.predefinedModel.comment=Download and use vetted models from HuggingFace.
 settingsConfigurable.service.llama.customModel.comment=Use your own GGUF model file from a local path on your computer.
 settingsConfigurable.service.custom.openai.testConnection.label=Test Connection


### PR DESCRIPTION
This change makes it so the user can select the key combination to send the message. Users may configure any combination of ctrl, alt, or shift (or the mac equivalents) plus enter. If any are configured, that combination plus enter will send the message, and enter by itself will insert a newline. If none are configured, enter by itself and any of the modifiers plus enter inserts a newline. This means the previous behavior of shift+enter to insert a newline is preserved.

Note, Chinese translations were not provided. I could just dump the strings through some translation service, but I have no way to verify the quality of such translations. And in technical matters, I don't trust automatic translations.