### PR TITLE
Use Bash for linux platforms

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/agent/tools/BashTool.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/agent/tools/BashTool.kt
@@ -529,11 +529,11 @@ class BashTool(
     }
 
     private fun buildShellCommand(command: String): List<String> {
-        val isWindows = System.getProperty("os.name").lowercase().contains("windows")
-        return if (isWindows) {
-            listOf("cmd", "/c", command)
-        } else {
-            listOf("sh", "-c", command)
+        val osName = System.getProperty("os.name").lowercase()
+        return when {
+            osName.contains("windows") -> listOf("cmd", "/c", command)
+            osName.contains("linux") -> listOf("bash", "-c", command)
+            else -> listOf("sh", "-c", command)
         }
     }
 


### PR DESCRIPTION
## Summary

Use Bash on linux-based OS to fix Bash-specific commands in BashTool.kt to resolve https://github.com/carlrobertoh/ProxyAI/issues/1188.

## Changes

Reworked buildShellCommand() function:
- it uses `when` statement now to add some platform-related flexibility;
- it uses bash on linux platforms;
- it still uses sh on other non-windows platforms where bash may be missing by default.

