### PR TITLE
feat: add focus actions for Agent and Chat tool window inputs

### DIFF
--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/FocusAgentInputAction.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/FocusAgentInputAction.kt
@@ -1,0 +1,29 @@
+package ee.carlrobert.codegpt.actions
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.wm.ToolWindowManager
+import ee.carlrobert.codegpt.toolwindow.agent.AgentToolWindowPanel
+
+class FocusAgentInputAction : AnAction() {
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("ProxyAI") ?: return
+        toolWindow.show {
+            val contentManager = toolWindow.contentManager
+            val agentContent = contentManager.contents.firstOrNull { it.tabName == "Agent" }
+                ?: contentManager.getContent(0)
+                ?: return@show
+            contentManager.setSelectedContent(agentContent)
+            (agentContent.component as? AgentToolWindowPanel)?.focusActiveInput()
+        }
+    }
+}

--- a/src/main/kotlin/ee/carlrobert/codegpt/actions/FocusChatInputAction.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/actions/FocusChatInputAction.kt
@@ -1,0 +1,28 @@
+package ee.carlrobert.codegpt.actions
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.wm.ToolWindowManager
+import ee.carlrobert.codegpt.toolwindow.chat.ChatToolWindowPanel
+
+class FocusChatInputAction : AnAction() {
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("ProxyAI") ?: return
+        toolWindow.show {
+            val contentManager = toolWindow.contentManager
+            val chatContent = contentManager.contents.firstOrNull { it.tabName == "Chat" }
+                ?: return@show
+            contentManager.setSelectedContent(chatContent)
+            (chatContent.component as? ChatToolWindowPanel)?.requestFocusForInput()
+        }
+    }
+}

--- a/src/main/kotlin/ee/carlrobert/codegpt/toolwindow/agent/AgentToolWindowPanel.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/toolwindow/agent/AgentToolWindowPanel.kt
@@ -85,6 +85,14 @@ class AgentToolWindowPanel(
 
     fun getTabbedPane(): AgentToolWindowTabbedPane = tabbedPane
 
+    fun focusActiveInput() {
+        landingPanel?.let {
+            it.requestFocusForTextArea()
+            return
+        }
+        contentManager.getActiveTabPanel()?.requestFocusForTextArea()
+    }
+
     private fun showTabsView() {
         disposeLandingPanel()
         centerLayout.show(centerPanel, TABS_CARD)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -319,6 +319,17 @@
       <override-text place="MainMenu" text="Open Settings"/>
       <override-text place="popup" use-text-of-place="MainMenu"/>
     </action>
+
+    <action
+      id="ProxyAI.FocusAgentInput"
+      text="ProxyAI: Focus Agent Input"
+      description="Open the ProxyAI tool window, switch to the Agent tab and focus its input"
+      class="ee.carlrobert.codegpt.actions.FocusAgentInputAction"/>
+    <action
+      id="ProxyAI.FocusChatInput"
+      text="ProxyAI: Focus Chat Input"
+      description="Open the ProxyAI tool window, switch to the Chat tab and focus its input"
+      class="ee.carlrobert.codegpt.actions.FocusChatInputAction"/>
     <action
       id="statusbar.enableCompletions"
       class="ee.carlrobert.codegpt.actions.EnableCompletionsAction">


### PR DESCRIPTION
Register two new actions (no default keybinding, not attached to any menu) so users can assign their own shortcuts in Settings > Keymap:

- ProxyAI.FocusAgentInput: show tool window, switch to Agent tab, focus input
- ProxyAI.FocusChatInput:  show tool window, switch to Chat tab,  focus input

For Agent, AgentToolWindowPanel#focusActiveInput() prefers the landing panel when present and falls back to the active tab; Chat reuses the existing ChatToolWindowPanel#requestFocusForInput().