### PR TITLE
fix: normalize line separators when initializing prompt editors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
+src/main/resources/prompts/**/*.txt text eol=lf

--- a/src/main/kotlin/ee/carlrobert/codegpt/settings/prompts/form/details/AbstractEditorPromptPanel.kt
+++ b/src/main/kotlin/ee/carlrobert/codegpt/settings/prompts/form/details/AbstractEditorPromptPanel.kt
@@ -35,7 +35,7 @@ abstract class AbstractEditorPromptPanel(
     private fun createEditor(): Editor {
         return service<EditorFactory>()
             .run {
-                createEditor(createDocument(details.instructions ?: ""))
+                createEditor(createDocument(StringUtil.convertLineSeparators(details.instructions ?: "")))
             }
             .apply {
                 settings.additionalLinesCount = 0


### PR DESCRIPTION
Settings -> ProxyAI -> Prompts could appear to hang ("loading" forever) on Windows when the plugin was built locally. Source .txt prompts checked out with autocrlf=true ended up CRLF inside the JAR, and AbstractEditorPromptPanel fed those CRLF strings straight into createDocument. IntelliJ then queued a background write action per editor to normalize the document, but those WAs sat blocked behind the modal Settings dialog's WriteIntentReadAction, each hitting the 10-second BG-WA timeout.

Fix it at both ends:
- Wrap details.instructions with StringUtil.convertLineSeparators before passing to createDocument, mirroring updateEditorText. This also protects against pre-existing CRLF that may already live in persisted CodeGPT_PromptsSettings.xml from older installs.
- Add a .gitattributes rule forcing src/main/resources/prompts/**/*.txt to eol=lf so the same condition cannot reappear on future Windows builds.